### PR TITLE
DEAM-122: Replace custom checkbox with native checkbox

### DIFF
--- a/src/app/modules/account/pages/contact-info/contact-info.component.html
+++ b/src/app/modules/account/pages/contact-info/contact-info.component.html
@@ -31,16 +31,12 @@
                 This is my mailing address.
                 </label>
             </div> -->
-            <div class="custom-control custom-checkbox">
-                <input type="checkbox"
-                    class="custom-control-input"
-                    id="isMailingAddress"
-                    [checked]="mspAccountApp.mailingSameAsResidentialAddress"
-                    (click)="toggleCheckBox()" />
-                <label class="custom-control-label" for="isMailingAddress">
-                This is my mailing address.
-                </label>
-            </div>
+            <common-checkbox
+                [label]="'This is my mailing address.'"
+                (dataChange)="mspAccountApp.mailingSameAsResidentialAddress = $event;"
+                [data]="mspAccountApp.mailingSameAsResidentialAddress"
+                class="ml-4">
+            </common-checkbox>
             <aside>
                 <h2> <strong> Mailing Address </strong></h2>
                 <p class="horizontal-line">Enter your mailing address - if it's different </p>

--- a/src/app/styles/overrides.scss
+++ b/src/app/styles/overrides.scss
@@ -207,22 +207,6 @@ accordion-group + accordion-group {
   padding-right: 7rem !important;
 }
 
-// Increase custom checkbox size.
-.custom-control-label::before {
-  width: 1.5rem !important;
-  height: 1.5rem !important;
-}
-
-.custom-control-label::after {
-  width: 1.5rem !important;
-  height: 1.5rem !important;
-}
-
-.custom-control-label {
-  padding-top: 0.25rem !important;
-  padding-left: 0.5rem !important;
-}
-
 // Increase checkbox size.
 common-checkbox {
   input {

--- a/src/app/styles/overrides.scss
+++ b/src/app/styles/overrides.scss
@@ -207,7 +207,7 @@ accordion-group + accordion-group {
   padding-right: 7rem !important;
 }
 
-// Increase checkbox size.
+// Increase custom checkbox size.
 .custom-control-label::before {
   width: 1.5rem !important;
   height: 1.5rem !important;
@@ -219,6 +219,18 @@ accordion-group + accordion-group {
 }
 
 .custom-control-label {
-  padding-top: .25rem !important;
+  padding-top: 0.25rem !important;
   padding-left: 0.5rem !important;
+}
+
+// Increase checkbox size.
+common-checkbox {
+  input {
+    width: 1.5rem;
+    height: 1.5rem;
+  }
+  label {
+    padding-top: 0.25rem;
+    padding-left: 0.5rem;
+  }
 }


### PR DESCRIPTION
I couldn't apply the custom styling to the `common-checkbox` component without heavily modifying the  common library. So I've removed the custom checkbox styling and replaced it with the native `common-checkbox` (the size has also been increased).