### PR TITLE
DEAM-309: Change gender desig. labels, add options

### DIFF
--- a/src/app/modules/account/components/update-request/update-request.component.html
+++ b/src/app/modules/account/components/update-request/update-request.component.html
@@ -110,7 +110,7 @@
     [supportDocList]="nameChangeDueToNameChangeDocs"
     [(supportDoc)]="person.updateNameDueToNameChangeDocType">
     <div sectionTitleInfo>
-      <h2><strong>Documents - Update name due to name change</strong></h2>
+      <h2><strong>Documents - Update name - due to name change</strong></h2>
       <p class="horizontal-line">
         Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} name change.
       </p>
@@ -142,7 +142,7 @@
       </aside>
     </div>
     <div sectionTitleInfo>
-      <h2><strong>Documents - Correct gender designation - due to change</strong></h2>
+      <h2><strong>Documents - Update gender designation - due to change</strong></h2>
       <p class="horizontal-line">
         Provide the required document(s) to support {{possessiveRelationshipNoun}} personal information update.
       </p>
@@ -187,7 +187,7 @@
     [supportDocList]="nameChangeDuetoErrorDocs"
     [(supportDoc)]="person.updateNameDueToErrorDocType">
     <div sectionTitleInfo>
-      <h2> <strong> Documents - Correct name </strong> </h2>
+      <h2> <strong> Documents - Correct name - due to error</strong> </h2>
       <p class="horizontal-line">
         Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
       </p>
@@ -209,7 +209,7 @@
     [supportDocList]="genderBirthdateChangeDocs"
     [(supportDoc)]="person.updateBirthdateDocType">
     <div sectionTitleInfo>
-      <h2> <strong> Documents - Correct birthdate </strong> </h2>
+      <h2> <strong> Documents - Correct birthdate - due to error</strong> </h2>
       <p class="horizontal-line">
         Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
       </p>
@@ -231,7 +231,7 @@
     [supportDocList]="genderBirthdateChangeDocs"
     [(supportDoc)]="person.updateGenderDesignationDocType">
     <div sectionTitleInfo>
-      <h2><strong>Documents - Correct gender</strong></h2>
+      <h2><strong>Documents - Correct gender - due to error</strong></h2>
       <p class="horizontal-line">
         Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
       </p>

--- a/src/app/modules/account/pages/child-info/update-child/update-child.component.html
+++ b/src/app/modules/account/pages/child-info/update-child/update-child.component.html
@@ -44,28 +44,6 @@
   </msp-support-documents>
 </div>
 
-<!-- Correct name - due to error -->
-<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
-  <common-checkbox
-    [label]="'Correct name - due to error'"
-    (dataChange)="child.updateNameDueToError = $event;"
-    [data]="child.updateNameDueToError">
-  </common-checkbox>
-</div>
-
-<div *ngIf="child.updateNameDueToError" class="add-document mb-4">
-  <msp-support-documents
-    [supportDocList]="nameChangeDuetoErrorDocs"
-    [(supportDoc)]="child.updateNameDueToErrorDocType">
-    <div sectionTitleInfo>
-      <h2> <strong> Documents - Correct name </strong> </h2>
-      <p class="horizontal-line">
-        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
-      </p>
-    </div>
-  </msp-support-documents>
-</div>
-
 <!-- Update name - due to name change -->
 <div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
   <common-checkbox
@@ -88,54 +66,10 @@
   </msp-support-documents>
 </div>
 
-<!-- Correct birthdate-->
+<!-- Update gender designation - due to change -->
 <div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
   <common-checkbox
-    [label]="'Correct birthdate'"
-    (dataChange)="child.updateBirthdate = $event;"
-    [data]="child.updateBirthdate">
-  </common-checkbox>
-</div>
-
-<div *ngIf="child.updateBirthdate" class="add-document mb-4">
-  <msp-support-documents
-    [supportDocList]="genderBirthdateChangeDocs"
-    [(supportDoc)]="child.updateBirthdateDocType">
-    <div sectionTitleInfo>
-      <h2> <strong> Documents - Correct birthdate </strong> </h2>
-      <p class="horizontal-line">
-        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
-      </p>
-    </div>
-  </msp-support-documents>
-</div>
-
-<!-- Correct gender -->
-<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
-  <common-checkbox
-    [label]="'Correct gender'"
-    (dataChange)="child.updateGenderDesignation = $event;"
-    [data]="child.updateGenderDesignation">
-  </common-checkbox>
-</div>
-
-<div *ngIf="child.updateGenderDesignation" class="add-document mb-4">
-  <msp-support-documents
-    [supportDocList]="genderBirthdateChangeDocs"
-    [(supportDoc)]="child.updateGenderDesignationDocType">
-    <div sectionTitleInfo>
-      <h2><strong>Documents - Correct gender</strong></h2>
-      <p class="horizontal-line">
-        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
-      </p>
-    </div>
-  </msp-support-documents>
-</div>
-
-<!-- Correct gender designation -->
-<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
-  <common-checkbox
-    [label]="'Correct gender designation'"
+    [label]="'Update gender designation - due to change'"
     (dataChange)="child.updateGender = $event;"
     [data]="child.updateGender">
   </common-checkbox>
@@ -156,10 +90,99 @@
       </aside>
     </div>
     <div sectionTitleInfo>
-      <h2><strong>Documents - Correct gender designation - due to change</strong></h2>
+      <h2><strong>Documents - Update gender designation - due to change</strong></h2>
       <p class="horizontal-line">
         Provide the required document(s) to support {{possessiveRelationshipNoun}} personal information update.
       </p>
     </div>
   </msp-support-documents>
+  <div class="mb-4"></div>
+  <msp-support-documents
+    [supportDocList]="genderChangeDocs"
+    [(supportDoc)]="child.updateGenderDocType2">
+  </msp-support-documents>
+
+  <div class="mb-4"></div>
+  <div requestAdditionInfo>
+    <div class="form-group p-sm-2">
+      <common-radio
+      name="additionalDoc"
+      [(ngModel)]="child.updateGenderAdditionalDocs"
+      label="Do you need to add an additional document?"
+      required>
+      </common-radio>
+    </div>
+  </div>
+  <msp-support-documents
+    *ngIf="child.updateGenderAdditionalDocs"
+    [supportDocList]="genderChangeDocs"
+    [(supportDoc)]="child.updateGenderDocType3">
+  </msp-support-documents>
 </div>
+
+<!-- Correct name - due to error -->
+<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
+  <common-checkbox
+    [label]="'Correct name - due to error'"
+    (dataChange)="child.updateNameDueToError = $event;"
+    [data]="child.updateNameDueToError">
+  </common-checkbox>
+</div>
+
+<div *ngIf="child.updateNameDueToError" class="add-document mb-4">
+  <msp-support-documents
+    [supportDocList]="nameChangeDuetoErrorDocs"
+    [(supportDoc)]="child.updateNameDueToErrorDocType">
+    <div sectionTitleInfo>
+      <h2> <strong> Documents - Correct name - due to error</strong> </h2>
+      <p class="horizontal-line">
+        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
+      </p>
+    </div>
+  </msp-support-documents>
+</div>
+
+<!-- Correct birthdate - due to error-->
+<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
+  <common-checkbox
+    [label]="'Correct birthdate - due to error'"
+    (dataChange)="child.updateBirthdate = $event;"
+    [data]="child.updateBirthdate">
+  </common-checkbox>
+</div>
+
+<div *ngIf="child.updateBirthdate" class="add-document mb-4">
+  <msp-support-documents
+    [supportDocList]="genderBirthdateChangeDocs"
+    [(supportDoc)]="child.updateBirthdateDocType">
+    <div sectionTitleInfo>
+      <h2> <strong> Documents - Correct birthdate - due to error</strong> </h2>
+      <p class="horizontal-line">
+        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
+      </p>
+    </div>
+  </msp-support-documents>
+</div>
+
+<!-- Correct gender designation - due to error -->
+<div role="dialog" aria-labelledby="q2" class="form-check mb-2" >
+  <common-checkbox
+    [label]="'Correct gender designation - due to error'"
+    (dataChange)="child.updateGenderDesignation = $event;"
+    [data]="child.updateGenderDesignation">
+  </common-checkbox>
+</div>
+
+<div *ngIf="child.updateGenderDesignation" class="add-document mb-4">
+  <msp-support-documents
+    [supportDocList]="genderBirthdateChangeDocs"
+    [(supportDoc)]="child.updateGenderDesignationDocType">
+    <div sectionTitleInfo>
+      <h2><strong>Documents - Correct gender - due to error</strong></h2>
+      <p class="horizontal-line">
+        Provide <b>one</b> of the required documents to support {{possessiveRelationshipNoun}} personal information update.
+      </p>
+    </div>
+  </msp-support-documents>
+</div>
+


### PR DESCRIPTION
Please review when convenient

What I did:

1) Changed `correct` to `update` where requested
2) Add missing options and document slots for update-child component
3) Reorder options to follow suit with update-request (used for AH and
spouse)

>## Screenshots of old version:
![old-child-updates](https://user-images.githubusercontent.com/32586431/86976468-59a79500-c12f-11ea-9e0c-1626603aeb38.PNG)
![old-child-updates-expanded](https://user-images.githubusercontent.com/32586431/86976470-59a79500-c12f-11ea-904e-c25000b520ff.PNG)
![old-spouse-adult-updates](https://user-images.githubusercontent.com/32586431/86976471-59a79500-c12f-11ea-9261-250af3e3ae2c.PNG)
![old-spouse-adult-updates-expanded](https://user-images.githubusercontent.com/32586431/86976472-5a402b80-c12f-11ea-9dd6-4d96c2e8a07b.PNG)
>## Screenshots of new version:
![new-child-updates](https://user-images.githubusercontent.com/32586431/86976465-58766800-c12f-11ea-956c-baaffde85fb6.PNG)
![new-child-updates-expanded](https://user-images.githubusercontent.com/32586431/86976466-590efe80-c12f-11ea-8b66-898e6e16005a.PNG)
![new-spouse-adult-updates](https://user-images.githubusercontent.com/32586431/86976467-590efe80-c12f-11ea-923c-7872985a8508.PNG)
