### PR TITLE
DEAM-321: Home page browser cross-compatibility

### DIFF
--- a/src/app/modules/account/pages/home/home.component.scss
+++ b/src/app/modules/account/pages/home/home.component.scss
@@ -11,8 +11,8 @@
 
 .home-container {
   font-family: Arial;
-  margin-top: 32px;
-  margin-bottom: 32px;
+  max-width: 1150px;
+  margin: 32px auto;
   @include remove-x-padding-at-tablet-size;
 
   &__grandchild-container {
@@ -32,12 +32,18 @@
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  padding: auto 5%;
+  padding: 6px 5%;
+  width: 100%;
   @include remove-x-padding-at-tablet-size;
+
+  > * {
+    width: 100%;
+  }
 
   &__icon {
     // top, horizontal, bottom
-    padding: 0 16px 16px;
+    padding: 6px 16px 16px;
+    text-align: center;
   }
 
   &__text {
@@ -48,6 +54,7 @@
   &__aside-wrapper {
       align-self: center;
       justify-self: center;
+      width: 100%;
   }
 }
 


### PR DESCRIPTION
IE needed width to be explicit in children of flex container and Firefox
doesn't recognize `auto` for padding in certain situations so
that was handled as well.

>## Screenshots of new version across all major browsers:
![home--chrome](https://user-images.githubusercontent.com/32586431/87099734-64c9f600-c1ff-11ea-813c-a383ba43cec1.PNG)
![home--edge](https://user-images.githubusercontent.com/32586431/87099735-65628c80-c1ff-11ea-8dc2-509820340b77.PNG)
![home--firefox](https://user-images.githubusercontent.com/32586431/87099736-65628c80-c1ff-11ea-9c0a-02b8c13668dc.PNG)
![home--ie](https://user-images.githubusercontent.com/32586431/87099737-65fb2300-c1ff-11ea-9f92-f52adb8b45ba.PNG)



