### PR TITLE
DEAM-291: More validation for child-info

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.html
+++ b/src/app/modules/account/components/moving-information/moving-information.component.html
@@ -156,9 +156,6 @@
         [dateRangeStart]='returnDateDuring12MonthsStartRange'
         [errorMessage]='returnDateErrorMessage'>
       </common-date>
-
-<!--TODO: Need to do checks to ensure return date is greater than departure date
-and check departure was within last 12 months - need to find error messages for this-->
     </div>
   </div>
 
@@ -217,6 +214,7 @@ and check departure was within last 12 months - need to find error messages for 
         name="over30DaysDeparture"
         label="Departure date"
         [(ngModel)]="person.departureDateDuring6MonthsDate"
+        [dateRangeStart]='departureDateDuring6MonthsStartRange'
         [dateRangeEnd]='departureDateDuring6MonthsEndRange'
         [errorMessage]='departureDateErrorMessage'>
       </common-date>

--- a/src/app/modules/account/components/moving-information/moving-information.component.ts
+++ b/src/app/modules/account/components/moving-information/moving-information.component.ts
@@ -6,7 +6,7 @@ import { environment } from '../../../../../environments/environment';
 import { Relationship } from 'app/models/relationship.enum';
 import { MspPerson } from '../../../../components/msp/model/msp-person.model';
 import { formatDateField } from '../../helpers/date';
-import { isBefore, subDays, addDays, addMonths } from 'date-fns';
+import { isBefore, isAfter, subDays, addDays, addMonths, subMonths } from 'date-fns';
 
 // TO BE removed - differenece need to be added to msp-core moving-info so that it will work with account
 @Component({
@@ -42,16 +42,16 @@ export class ChildMovingInformationComponent extends Base implements OnInit {
 
   relationship: string = 'you';
   departureDateErrorMessage: ErrorMessage = {
-    invalidRange: 'Date must be at least 30 days before return date.'
+    invalidRange: 'Date must be more than 30 days before return date and within the next six months.'
   }
   returnDateErrorMessage: ErrorMessage = {
-    invalidRange: 'Date must be at least 30 days after departure date.'
+    invalidRange: 'Date must be more than 30 days after departure date.'
   }
   dischargeDateErrorMessage: ErrorMessage = {
     invalidRange: 'Date must be greater than the date of birth.'
   }
   departure12MonthsErrorMessage: ErrorMessage = {
-    invalidRange: 'Date must be within the last 12 months, and at least 30 days before the return date.'
+    invalidRange: 'Date must be within the last 12 months, and more than 30 days before the return date.'
   }
   adoptionDateErrorMessage: ErrorMessage = {
     invalidRange: 'Date must be after the birthdate.'
@@ -186,6 +186,11 @@ export class ChildMovingInformationComponent extends Base implements OnInit {
     return date;
   }
 
+  get date6MonthsFromNow(): Date {
+    const date: Date = new Date();
+    return addMonths(date, 6);
+  }
+
   get mostRecentMoveToBCErrorMessage() {
     if (this.person.dateOfBirth) {
       return {
@@ -214,13 +219,13 @@ export class ChildMovingInformationComponent extends Base implements OnInit {
     if (this.person.returnDateDuring12MonthsDate
       && this.person.returnDateDuring12MonthsDate instanceof Date
       && isBefore(this.person.returnDateDuring12MonthsDate, this.dateToday)) {
-      return subDays(this.person.returnDateDuring12MonthsDate, 31);
-    } else {
-      return this.dateToday;
+        return subDays(this.person.returnDateDuring12MonthsDate, 31);
+      } else {
+        return this.dateToday;
+      }
     }
-  }
 
-  get returnDateDuring12MonthsStartRange() {
+    get returnDateDuring12MonthsStartRange() {
     if (this.person.departureDateDuring12MonthsDate
       && this.person.departureDateDuring12MonthsDate instanceof Date) {
       return addDays(this.person.departureDateDuring12MonthsDate, 31)
@@ -229,23 +234,25 @@ export class ChildMovingInformationComponent extends Base implements OnInit {
     }
   }
 
-  get departureDateDuring6MonthsEndRange() {
-    if (this.person.returnDateDuring6MonthsDate
-      && this.person.returnDateDuring6MonthsDate instanceof Date
-      && isBefore(this.person.returnDateDuring6MonthsDate, addMonths(this.dateToday, 6))) {
-      return subDays(this.person.returnDateDuring6MonthsDate, 31);
-    } else {
-      return addMonths(this.dateToday, 6);
-    }
+  // Leaving today earliest
+  get departureDateDuring6MonthsStartRange() {
+    return this.dateToday;
   }
 
-  get returnDateDuring6MonthsStartRange() {
-    if (this.person.departureDateDuring6MonthsDate
+  // Latest they can leave is 31 days before six months from now
+  get departureDateDuring6MonthsEndRange() {
+        return subDays(addMonths(this.dateToday, 6), 31);
+    }
+
+    // Earliest they can get back is 31 days after the departure date
+    get returnDateDuring6MonthsStartRange() {
+      if (this.person.departureDateDuring6MonthsDate
       && this.person.departureDateDuring6MonthsDate instanceof Date) {
       return addDays(this.person.departureDateDuring6MonthsDate, 31)
     } else {
-      return this.dateToday;
+      return addDays(this.dateToday, 31);
     }
+
   }
 
   get showlivedInBC() {

--- a/src/app/modules/account/pages/child-info/child-info.component.ts
+++ b/src/app/modules/account/pages/child-info/child-info.component.ts
@@ -10,6 +10,8 @@ import { Relationship } from 'app/models/relationship.enum';
 import { StatusInCanada } from 'app/modules/msp-core/models/canadian-status.enum';
 import { SupportDocumentTypes } from 'app/modules/msp-core/models/support-documents.enum';
 import { BaseForm } from '../../models/base-form';
+import { CancellationReasons } from '../../../../models/status-activities-documents';
+
 
 const DOM_REFRESH_TIMEOUT = 50;
 
@@ -149,6 +151,10 @@ export class ChildInfoComponent extends BaseForm implements OnInit, AfterViewIni
     return this.dataService.accountApp.updatedChildren;
   }
 
+  get addedChildren(): MspPerson[] {
+    return this.dataService.accountApp.addedChildren;
+  }
+
   removeChild(idx: number, op: OperationActionType): void {
     this.dataService.accountApp.removeChild(idx, op);
   }
@@ -207,9 +213,35 @@ export class ChildInfoComponent extends BaseForm implements OnInit, AfterViewIni
     return valid;
   }
 
+  checkAdd() {
+    let valid = true;
+    this.addedChildren.forEach(addedChild => {
+      if (addedChild.newlyAdopted) {
+        valid = valid && addedChild.adoptedDate !== undefined;
+        valid = valid && addedChild.adoptedDate != null;
+      }
+    })
+    return valid;
+  }
+
+  checkRemove() {
+    let valid = true;
+    this.removedChildren.forEach(removedChild => {
+      valid = valid && removedChild.cancellationReason !== undefined;
+      valid = valid && removedChild.cancellationReason != null;
+    })
+    return valid;
+  }
+
   canContinue(): boolean {
     let valid = super.canContinue();
-    if (this.dataService.accountApp.updatedChildren.length > 0) {
+    if (this.dataService.accountApp.addedChildren) {
+      valid = valid && this.checkAdd();
+    }
+    if (this.dataService.accountApp.removedChildren) {
+      valid = valid && this.checkRemove();
+    }
+    if (this.dataService.accountApp.updatedChildren) {
       valid = valid && this.checkUpdate();
     }
     return valid;


### PR DESCRIPTION
Very basic validation for removed and added children, date validation
for 12 and 6 month departure and return dates is working, but there remains a
slightly annoying issue where if both dates are invalid, you have to
fix both then click off of both before the error goes away. Leaving
this in favour of working on higher priority issues