### PR TITLE
DEAM-329: Prevent error on submission for child

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.html
+++ b/src/app/modules/account/components/moving-information/moving-information.component.html
@@ -25,6 +25,7 @@
     <div *ngIf="person.livedInBCSinceBirth === false" class="form-group col-sm-6 p-sm-2">
       <label for="movedFromProvinceOrCountry" class="control-label">From (province or country)</label>
       <input type="text"
+        name="movedFromProvinceOrCountry_{{objectId}}"
         class="form-control"
         id="movedFromProvinceOrCountry"
         [(ngModel)]="person.movedFromProvinceOrCountry"
@@ -311,6 +312,7 @@ and check departure was within last 12 months - need to find error messages for 
     <div *ngIf="person.schoolOutsideOfBC" >
       <div class="form-group col-sm-6 p-sm-2">
         <common-date
+          name="departureDate_{{objectId}}"
           label="Departure date from B.C."
           [restrictDate]="'past'"
           [(ngModel)]="person.departureDate">
@@ -332,6 +334,7 @@ and check departure was within last 12 months - need to find error messages for 
 
     <div class="form-group">
       <common-date
+        name="studiesDepartureDate_{{objectId}}"
         label="Date studies will begin"
         [(ngModel)]="person.studiesDepartureDate">
       </common-date>
@@ -339,6 +342,7 @@ and check departure was within last 12 months - need to find error messages for 
 
     <div class="form-group">
       <common-date
+        name="studiesFinishedDate_{{objectId}}"
         label="Date studies will finish"
         [(ngModel)]="person.studiesFinishedDate">
       </common-date>

--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -1036,16 +1036,10 @@ export class MspApiAccountService extends AbstractHttpService {
         from.declarationForOutsideOver30Days === true ? 'Y' : 'N';
       if (from.declarationForOutsideOver30Days) {
         if (from.outOfBCRecord.hasDeparture) {
-          to.outsideBC.departureDate = format(
-            from.outOfBCRecord.departureDate,
-            this.ISO8601DateFormat
-          );
+          to.outsideBC.departureDate = String(from.outOfBCRecord.departureDate)
         }
         if (from.outOfBCRecord.hasReturn) {
-          to.outsideBC.returnDate = format(
-            from.outOfBCRecord.returnDate,
-            this.ISO8601DateFormat
-          );
+          to.outsideBC.returnDate = String(from.outOfBCRecord.returnDate)
         }
         to.outsideBC.familyMemberReason = from.outOfBCRecord.reason;
         to.outsideBC.destination = from.outOfBCRecord.location;
@@ -1060,17 +1054,13 @@ export class MspApiAccountService extends AbstractHttpService {
         from.plannedAbsence === true ? 'Y' : 'N';
       if (from.plannedAbsence) {
         if (from.planOnBeingOutOfBCRecord.hasDeparture) {
-          to.outsideBCinFuture.departureDate = format(
-            from.planOnBeingOutOfBCRecord.departureDate,
-            this.ISO8601DateFormat
-          );
+          to.outsideBCinFuture.departureDate = String(from.planOnBeingOutOfBCRecord.departureDate)
         }
+
         if (from.planOnBeingOutOfBCRecord.hasReturn) {
-          to.outsideBCinFuture.returnDate = format(
-            from.planOnBeingOutOfBCRecord.returnDate,
-            this.ISO8601DateFormat
-          );
+          to.outsideBCinFuture.returnDate = String(from.planOnBeingOutOfBCRecord.returnDate);
         }
+
         to.outsideBCinFuture.familyMemberReason =
           from.planOnBeingOutOfBCRecord.reason;
         to.outsideBCinFuture.destination =


### PR DESCRIPTION
What I did:
1) Stop console errors by adding missing name attributes to ngModel
bindings
2) Temporarily remove use of date formatter in msp-api-account service
(in method `populateNewBeneficiaryDetailsForChild`)

The failure on submission was for the 31 days or more out of province fields (6 months in future, last 12 months) and was only happening for child.