### PR TITLE
DEAM-338: Fix date range, radio button issues

### DIFF
--- a/src/app/modules/account/components/personal-information/personal-information.component.ts
+++ b/src/app/modules/account/components/personal-information/personal-information.component.ts
@@ -166,6 +166,7 @@ export class AccountPersonalInformationComponent<T extends IPersonalInformation>
     } else if (this.person.relationship === Relationship.ChildUnder19) {
       this.dobErrorMsg = {invalidRange: 'A child must be less than 19 years old.'};
       this.dobStartRange = subYears( this._today, 19 );
+      this.dobEndRange = this._today;
     } else if (this.person.relationship === Relationship.Child) {
       this.dobErrorMsg = {invalidRange: 'A child must be less than 24 years old.'};
       this.dobStartRange = subYears( this._today, 24 );

--- a/src/app/modules/account/pages/child-info/add-child/add-child.component.html
+++ b/src/app/modules/account/pages/child-info/add-child/add-child.component.html
@@ -1,22 +1,19 @@
 <div class="form-group">
   <common-radio
+    name="ageCategory_{{objectId}}"
     id="AgeCategory_{{index}}"
-    [value]="child.relationship"
-    (valueChange)="setChildRelationship($event)"
+    [(ngModel)]="childRelationship"
     label="How old is the child?"
     [radioLabels]="childAgeCategory"
     required>
   </common-radio>
-
-  <div class="form-group">
-    <common-radio
+  <common-radio
       name="activeCoverage_{{objectId}}"
       [(ngModel)]="hasActiveMedicalCoverage"
       label="Does your child currently have active Medical Services Plan coverage?"
       [radioLabels]='[{"label": "No", "value": false }, {"label": "Yes", "value": true}]'
       required>
-    </common-radio>
-  </div>
+  </common-radio>
 </div>
 
 <div *ngIf="child.relationship !== undefined && hasActiveMedicalCoverage !== undefined">
@@ -68,38 +65,38 @@
     </div>
   </div>
 
-    <!-- Child's Personal Info -->
-    <msp-personal-information
-      [person]="child"
-      [phnList]="phnList">
-      <div sectionTitleInfo>
-        <h2>Child's Personal Information</h2>
-        <p class="border-bottom">
-          Enter child's legal name as it appears on their official Canadian identity
-          documents, e.g., birth certificate, permanent resident card, passport.
-        </p>
-      </div>
-    </msp-personal-information>
-
-    <!-- Child's Gender -->
-    <div class="row">
-      <div class="col-md-4">
-        <common-radio
-          [value]="child.gender"
-          label='Gender'
-          [radioLabels]='[{"label": "Female", "value": "F"}, {"label": "Male", "value": "M"}]'
-          (valueChange)="setGender($event)"
-          required>
-        </common-radio>
-      </div>
+  <!-- Child's Personal Info -->
+  <account-personal-information
+    [person]="child"
+    [phnList]="phnList">
+    <div sectionTitleInfo>
+      <h2>Child's Personal Information</h2>
+      <p class="border-bottom">
+        Enter child's legal name as it appears on their official Canadian identity
+        documents, e.g., birth certificate, permanent resident card, passport.
+      </p>
     </div>
+  </account-personal-information>
 
-    <!-- Child's Residency Information -->
-    <msp-child-moving-information
-      [person]="child">
-      <div sectionTitleInfo>
-        <h2><strong>Child's Residency Information</strong></h2>
-        <p class="border-bottom"></p>
-      </div>
-    </msp-child-moving-information>
+  <!-- Child's Gender -->
+  <div class="row">
+    <div class="col-md-4">
+      <common-radio
+        [value]="child.gender"
+        label='Gender'
+        [radioLabels]='[{"label": "Female", "value": "F"}, {"label": "Male", "value": "M"}]'
+        (valueChange)="setGender($event)"
+        required>
+      </common-radio>
+    </div>
+  </div>
+
+  <!-- Child's Residency Information -->
+  <msp-child-moving-information
+    [person]="child">
+    <div sectionTitleInfo>
+      <h2><strong>Child's Residency Information</strong></h2>
+      <p class="border-bottom"></p>
+    </div>
+  </msp-child-moving-information>
 </div>


### PR DESCRIPTION
What I did:
1) Switching to ngModel as opposed to value and value change function
(as recommended by K). This fixed an issue I had just found where
selecting only the active coverage radio button but not yet the age
range radio enabled the continue. (You can try this on the dev deploy)
2) Switched from msp-personal-information cmpnt to the new
account-personal-information cmpnt
3) Fixed the 0-18 and 19-24 date range issue. It was just missing an
end range setting

Clicking between the 0-18 and 19-24 options no longer messes up date validation