### PR TITLE
DEAM-268: Get missing child dates, info into PDF

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.html
+++ b/src/app/modules/account/components/moving-information/moving-information.component.html
@@ -322,7 +322,7 @@ and check departure was within last 12 months - need to find error messages for 
           name="departureDate_{{objectId}}"
           label="Departure date from B.C."
           [restrictDate]="'past'"
-          [(ngModel)]="person.departureDate">
+          [(ngModel)]="person.studiesDepartureDate">
         </common-date>
       </div>
     </div>
@@ -341,9 +341,9 @@ and check departure was within last 12 months - need to find error messages for 
 
     <div class="form-group col-sm-6 p-sm-2">
       <common-date
-        name="studiesDepartureDate_{{objectId}}"
+        name="studiesBeginDate_{{objectId}}"
         label="Date studies will begin"
-        [(ngModel)]="person.studiesDepartureDate"
+        [(ngModel)]="person.studiesBeginDate"
         required>
       </common-date>
     </div>

--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -861,6 +861,7 @@ export class MspApiAccountService extends AbstractHttpService {
     if (from.hasDob) {
       to.birthDate = format(from.dob, this.ISO8601DateFormat);
     }
+
     if (from.gender != null) {
       to.gender = <GenderType>from.gender.toString();
     }
@@ -869,17 +870,82 @@ export class MspApiAccountService extends AbstractHttpService {
       to.phn = from.previous_phn.replace(new RegExp('[^0-9]', 'g'), '');
     }
 
-    //TODO //FIXME once data model is implemented , verify this..Also might need another convertResidency for DEAM
     if (from.status != null) {
       to.citizenship = this.findCitizenShip(from.status, from.currentActivity);
     }
+
     if (from.isExistingBeneficiary != null) {
       to.isExistingBeneficiary =
         from.isExistingBeneficiary === true ? 'Y' : 'N';
     }
+
     if (from.operationActionType === OperationActionTypeEnum.Add) {
       this.populateNewBeneficiaryDetailsForChild(from, to);
     }
+
+    to.livedInBC = LivedInBCTypeFactory.make();
+
+    to.livedInBC.hasLivedInBC = from.liveInBC ? 'Y' : 'N';
+
+    if (from.arrivalToBCDate) {
+      to.livedInBC.recentBCMoveDate = format(
+        from.arrivalToBCDate,
+        this.ISO8601DateFormat
+      );
+    }
+
+    if (from.arrivalToCanadaDate) {
+      to.livedInBC.recentCanadaMoveDate = format(
+        from.arrivalToCanadaDate,
+        this.ISO8601DateFormat
+      );
+    }
+
+    if (from.madePermanentMoveToBC) {
+      to.livedInBC.isPermanentMove =
+        from.madePermanentMoveToBC === true ? 'Y' : 'N';
+    }
+
+    if (from.movedFromProvinceOrCountry) {
+      to.livedInBC.prevProvinceOrCountry = from.movedFromProvinceOrCountry;
+    }
+
+    if (from.healthNumberFromOtherProvince) {
+      to.livedInBC.prevHealthNumber = from.healthNumberFromOtherProvince;
+    }
+
+    if (from.declarationForOutsideOver30Days) {
+      to.outsideBC = OutsideBCTypeFactory.make();
+      to.outsideBC.beenOutsideBCMoreThan = 'Y';
+      to.outsideBC.familyMemberReason = from.departureReason12Months;
+      to.outsideBC.destination = from.departureDestination12Months;
+      if (from.departureDateDuring12MonthsDate) {
+        to.outsideBC.departureDate = format(from.departureDateDuring12MonthsDate, this.ISO8601DateFormat);
+      }
+      if (from.returnDateDuring12MonthsDate) {
+        to.outsideBC.returnDate = format(from.returnDateDuring12MonthsDate, this.ISO8601DateFormat);
+      }
+    } else if (from.declarationForOutsideOver30Days === false) {
+      to.outsideBC = OutsideBCTypeFactory.make();
+      to.outsideBC.beenOutsideBCMoreThan = 'N';
+    }
+
+    if (from.declarationForOutsideOver60Days) {
+      to.outsideBCinFuture = OutsideBCTypeFactory.make();
+      to.outsideBCinFuture.beenOutsideBCMoreThan = 'Y';
+      to.outsideBCinFuture.familyMemberReason = from.departureReason;
+      to.outsideBCinFuture.destination = from.departureDestination;
+      if (from.departureDateDuring6MonthsDate) {
+        to.outsideBCinFuture.departureDate = format(from.departureDateDuring6MonthsDate, this.ISO8601DateFormat);
+      }
+      if (from.returnDateDuring6MonthsDate) {
+        to.outsideBCinFuture.returnDate = format(from.returnDateDuring6MonthsDate, this.ISO8601DateFormat);
+      }
+    } else if (from.declarationForOutsideOver60Days === false) {
+      to.outsideBCinFuture = OutsideBCTypeFactory.make();
+      to.outsideBCinFuture.beenOutsideBCMoreThan = 'N';
+    }
+
     // Child 19-24
     if (from.relationship === Relationship.Child19To24) {
       if (from.schoolName) {


### PR DESCRIPTION
Please review when convenient

What I did:
1) Fix incorrect ngModel attrs
2) Add the following missing items to child PDF output:
  - Outside province info (reasons, destinations, dates, boolean)
  - Lived in BC info (dates, booleans, previous health number)
  - School info (name, address, dates)

The JSON looks fairly complete now, but I think there may be a small issue with the willBeAway field. If you a child is both discharged from military service and away for school, fulltimeStudent will be set to "N". I'm not sure if the actual situation is even possible or all the different sorts of discharge the discharge field can refer to but it's possibly an issue.

Attached is previous (incomplete) JSON and new (complete) JSON, zipped
[payloads.zip](https://github.com/bcgov/MyGovBC-MSP/files/4918367/payloads.zip)


