### PR TITLE
DEAM-344: Edit package.json script for all OS

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "prestart": "npm install",
     "preinstall": "rm -rf node_modules/",
     "start": "npm run dev",
-    "dev": "ng serve --host='0.0.0.0' --port=4304 -o",
+    "dev": "ng serve --host=\"0.0.0.0\" --port=4304 -o",
     "dev-build": "ng build",
     "prebuild": "node src/version.js",
     "build": "ng build --prod",


### PR DESCRIPTION
Changed `'0.0.0.0'` to `\"0.0.0.0\"` so that all OS can run the 
`dev` script. Previously didn't work on Windows