### PR TITLE
DEAM-348: Make "From" field mandatory if visible

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.html
+++ b/src/app/modules/account/components/moving-information/moving-information.component.html
@@ -236,8 +236,6 @@
         [errorMessage]='returnDateErrorMessage'>
       </common-date>
     </div>
-<!--TODO: Need to do checks to ensure return date is greater than departure date
-and check departure was within last 12 months - need to find error messages for this-->
   </div>
 
   <!-- released from the Canadian Armed Forces -->

--- a/src/app/modules/account/models/base-form.ts
+++ b/src/app/modules/account/models/base-form.ts
@@ -35,6 +35,10 @@ export class BaseForm extends AbstractForm implements OnInit, AfterViewInit, OnD
     }
   }
 
+  isSet(val) {
+    return val !== undefined && val !== null;
+  }
+
   continue() {
     // console.log( 'Continue: base form to be overriden');
   }

--- a/src/app/modules/account/pages/spouse-info/add-spouse/add-spouse.component.html
+++ b/src/app/modules/account/pages/spouse-info/add-spouse/add-spouse.component.html
@@ -10,7 +10,7 @@
 </div>
 
 <div *ngIf="spouse.immigrationStatusChange !== undefined">
-  <div *ngIf="spouse.immigrationStatusChange == false">
+  <div *ngIf="spouse.immigrationStatusChange === false">
     <!-- Spouse's Status in Canada -->
     <div class="col-sm-6 add-document">
       <msp-canadian-status
@@ -174,7 +174,7 @@
   </div>
 
   <!-- Spouse's Residency Information -->
-  <div *ngIf="spouse.immigrationStatusChange == false">
+  <div *ngIf="spouse.immigrationStatusChange === false">
     <msp-child-moving-information
       [person]="spouse">
       <div sectionTitleInfo>

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -147,64 +147,45 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
     // Don't bother checking if they aren't adding a spouse
     if (this.accountApp.hasSpouseAdded === true) {
       // Ticked "...active Medical Services Plan coverage?"
-      valid = valid && this.addedSpouse.immigrationStatusChange !== undefined
-        && this.addedSpouse.immigrationStatusChange !== null
+      valid = valid && this.isSet(this.addedSpouse.immigrationStatusChange)
         // Ticked gender radio
-        && this.addedSpouse.gender !== undefined
-        && this.addedSpouse.gender !== null
+        && this.isSet(this.addedSpouse.gender)
         // Ticked "Has your spouse's name changed due to marriage?"
-        && this.addedSpouse.updateNameDueToMarriage !== undefined
-        && this.addedSpouse.updateNameDueToMarriage !== null;
+        && this.isSet(this.addedSpouse.updateNameDueToMarriage)
 
       // Ticked yes to name changed due to marriage
       if (this.addedSpouse.updateNameDueToMarriage === true) {
         // Check that they inputted a requested lastname and that they uploaded at least one supporting doc
-        valid = valid && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined
-          && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== null
+        valid = valid && this.isSet(this.addedSpouse.updateNameDueToMarriageRequestedLastName)
           && typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string'
           && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0
           && this.addedSpouse.updateNameDueToMarriageRequestedLastName.match(/\d+/g) === null
-          && this.addedSpouse.updateNameDueToMarriageDocType.images !== undefined
-          && this.addedSpouse.updateNameDueToMarriageDocType.images !== null
+          && this.isSet(this.addedSpouse.updateNameDueToMarriageDocType.images)
           && this.addedSpouse.updateNameDueToMarriageDocType.images.length > 0;
       }
 
       // If they don't have existing coverage
       if (this.addedSpouse.immigrationStatusChange === false) {
         // All radio buttons visible at this point have been ticked, and one update doc has been uploaded
-        valid = valid && this.addedSpouse.updateStatusInCanadaDocType !== undefined
-          && this.addedSpouse.updateStatusInCanadaDocType !== null
-          && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined
-          && this.addedSpouse.updateStatusInCanadaDocType.images !== null
+        valid = valid && this.isSet(this.addedSpouse.updateStatusInCanadaDocType)
+          && this.isSet(this.addedSpouse.updateStatusInCanadaDocType.images)
           && this.addedSpouse.updateStatusInCanadaDocType.images.length > 0
-          && this.addedSpouse.hasNameChange !== undefined
-          && this.addedSpouse.hasNameChange !== null
-          && this.addedSpouse.livedInBCSinceBirth !== undefined
-          && this.addedSpouse.livedInBCSinceBirth !== null
-          && this.addedSpouse.madePermanentMoveToBC !== undefined
-          && this.addedSpouse.madePermanentMoveToBC !== null
-          && this.addedSpouse.declarationForOutsideOver30Days !== undefined
-          && this.addedSpouse.declarationForOutsideOver30Days !== null
-          && this.addedSpouse.declarationForOutsideOver60Days !== undefined
-          && this.addedSpouse.declarationForOutsideOver60Days !== null
-          && this.addedSpouse.hasBeenReleasedFromArmedForces !== undefined
-          && this.addedSpouse.hasBeenReleasedFromArmedForces !== null;
-
+          && this.isSet(this.addedSpouse.hasNameChange)
+          && this.isSet(this.addedSpouse.livedInBCSinceBirth)
+          && this.isSet(this.addedSpouse.madePermanentMoveToBC)
+          && this.isSet(this.addedSpouse.declarationForOutsideOver30Days)
+          && this.isSet(this.addedSpouse.declarationForOutsideOver60Days)
+          && this.isSet(this.addedSpouse.hasBeenReleasedFromArmedForces)
         // Yes to name change "due to legal name change"
         if (this.addedSpouse.hasNameChange === true) {
-          valid = valid && this.addedSpouse.nameChangeDocs !== undefined
-            && this.addedSpouse.nameChangeDocs !== null
-            && this.addedSpouse.nameChangeDocs.images !== undefined
-            && this.addedSpouse.nameChangeDocs.images !== null
+          valid = valid && this.isSet(this.addedSpouse.nameChangeDocs)
+            && this.isSet(this.addedSpouse.nameChangeDocs.images)
             && this.addedSpouse.nameChangeDocs.images.length > 0
-            && this.addedSpouse.hasNameChangeAdditional !== undefined
-            && this.addedSpouse.hasNameChangeAdditional !== null;
+            && this.isSet(this.addedSpouse.hasNameChangeAdditional);
           // Yes to an additional document
           if (this.addedSpouse.hasNameChangeAdditional === true) {
-            valid = valid && this.addedSpouse.nameChangeAdditionalDocs !== undefined
-              && this.addedSpouse.nameChangeAdditionalDocs !== null
-              && this.addedSpouse.nameChangeAdditionalDocs.images !== undefined
-              && this.addedSpouse.nameChangeAdditionalDocs.images !== null
+            valid = valid && this.isSet(this.addedSpouse.nameChangeAdditionalDocs)
+              && this.isSet(this.addedSpouse.nameChangeAdditionalDocs.images)
               && this.addedSpouse.nameChangeAdditionalDocs.images.length > 0;
           }
         }
@@ -212,44 +193,32 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
         // No to "lived in BC since birth"
         if (this.addedSpouse.livedInBCSinceBirth === false) {
           // Check they inputted the province or country they came from and the date
-          valid = valid && this.addedSpouse.arrivalToBCDate !== undefined
-            && this.addedSpouse.arrivalToBCDate !== null
-            && this.addedSpouse.movedFromProvinceOrCountry !== undefined
-            && this.addedSpouse.movedFromProvinceOrCountry !== null
+          valid = valid && this.isSet(this.addedSpouse.arrivalToBCDate)
+            && this.isSet(this.addedSpouse.movedFromProvinceOrCountry)
             && typeof this.addedSpouse.movedFromProvinceOrCountry === 'string'
             && this.addedSpouse.movedFromProvinceOrCountry.length > 0
         }
 
         // Yes to "more than 30 days in the last 12 months"
         if (this.addedSpouse.declarationForOutsideOver30Days === true) {
-          valid = valid && this.addedSpouse.departureDateDuring12MonthsDate !== undefined
-            && this.addedSpouse.departureDateDuring12MonthsDate !== null
-            && this.addedSpouse.returnDateDuring12MonthsDate !== undefined
-            && this.addedSpouse.returnDateDuring12MonthsDate !== null
-            && this.addedSpouse.departureReason12Months !== undefined
-            && this.addedSpouse.departureReason12Months !== null
-            && this.addedSpouse.departureDestination12Months !== undefined
-            && this.addedSpouse.departureDestination12Months !== null;
+          valid = valid && this.isSet(this.addedSpouse.departureDateDuring12MonthsDate)
+            && this.isSet(this.addedSpouse.returnDateDuring12MonthsDate)
+            && this.isSet(this.addedSpouse.departureReason12Months)
+            && this.isSet(this.addedSpouse.departureDestination12Months)
         }
 
         // Yes to "more than 30 days in the next 6 months"
         if (this.addedSpouse.declarationForOutsideOver60Days === true) {
-          valid = valid && this.addedSpouse.departureDateDuring6MonthsDate !== undefined
-            && this.addedSpouse.departureDateDuring6MonthsDate !== null
-            && this.addedSpouse.returnDateDuring6MonthsDate !== undefined
-            && this.addedSpouse.returnDateDuring6MonthsDate !== null
-            && this.addedSpouse.departureReason !== undefined
-            && this.addedSpouse.departureReason !== null
-            && this.addedSpouse.departureDestination !== undefined
-            && this.addedSpouse.departureDestination !== null;
+          valid = valid && this.isSet(this.addedSpouse.departureDateDuring6MonthsDate)
+            && this.isSet(this.addedSpouse.returnDateDuring6MonthsDate)
+            && this.isSet(this.addedSpouse.departureReason)
+            && this.isSet(this.addedSpouse.departureDestination)
         }
 
         // Yes to "released from Canadian Armed Forces"
         if (this.addedSpouse.hasBeenReleasedFromArmedForces === true) {
-          valid = valid && this.addedSpouse.dischargeDate !== undefined
-            && this.addedSpouse.dischargeDate !== null
-            && this.addedSpouse.nameOfInstitute !== undefined
-            && this.addedSpouse.nameOfInstitute !== null;
+          valid = valid && this.isSet(this.addedSpouse.dischargeDate)
+            && this.isSet(this.addedSpouse.nameOfInstitute)
         }
       }
     }

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -146,42 +146,117 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
     if (this.accountApp.hasSpouseAdded === true) {
       // Checking radio buttons have been ticked
       valid = valid && this.addedSpouse.immigrationStatusChange !== undefined
-        && this.addedSpouse.immigrationStatusChange != null
+        && this.addedSpouse.immigrationStatusChange !== null
         && this.addedSpouse.gender !== undefined
-        && this.addedSpouse.gender != null
+        && this.addedSpouse.gender !== null
         && this.addedSpouse.updateNameDueToMarriage !== undefined
-        && this.addedSpouse.updateNameDueToMarriage != null
-        && this.addedSpouse.hasNameChange !== undefined
-        && this.addedSpouse.hasNameChange != null;
+        && this.addedSpouse.updateNameDueToMarriage !== null;
+
+        console.log('beginning passes:', valid);
 
       if (this.addedSpouse.updateStatusInCanada === true) {
         // Check that they have at least one document to support the status change
         valid = valid && this.addedSpouse.updateStatusInCanadaDocType !== undefined
-          && this.addedSpouse.updateStatusInCanadaDocType != null
+          && this.addedSpouse.updateStatusInCanadaDocType !== null
           && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined
           && this.addedSpouse.updateStatusInCanadaDocType.images !== null
           && this.addedSpouse.updateStatusInCanadaDocType.images.length > 0;
       }
 
+      console.log(
+        'updateStatus passes',
+        valid,
+        this.addedSpouse.updateStatusInCanadaDocType !== null,
+        this.addedSpouse.updateStatusInCanadaDocType.images !== undefined,
+        this.addedSpouse.updateStatusInCanadaDocType.images !== null
+      );
+
       if (this.addedSpouse.updateNameDueToMarriage === true) {
         // Check that they inputted a requested lastname and that they uploaded at least one supporting doc
         valid = valid && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined
-          && this.addedSpouse.updateNameDueToMarriageRequestedLastName != null
+          && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== null
+          && typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string'
           && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0
           && this.addedSpouse.updateNameDueToMarriageRequestedLastName.match(/\d+/g) === null
-          && this.addedSpouse.nameChangeDocs.images !== undefined
-          && this.addedSpouse.nameChangeDocs.images != null
-          && this.addedSpouse.nameChangeDocs.images.length > 0;
+          && this.addedSpouse.updateNameDueToMarriageDocType.images !== undefined
+          && this.addedSpouse.updateNameDueToMarriageDocType.images !== null
+          && this.addedSpouse.updateNameDueToMarriageDocType.images.length > 0;
       }
 
-      if (this.addedSpouse.livedInBCSinceBirth === false) {
-        // Check they inputted the province or country they came from
-        valid = valid && this.addedSpouse.movedFromProvinceOrCountry !== undefined
-          && this.addedSpouse.movedFromProvinceOrCountry != null
-          && this.addedSpouse.movedFromProvinceOrCountry.length > 0;
+      console.log('updateName passes:', valid, this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined,
+        this.addedSpouse.updateNameDueToMarriageRequestedLastName !== null,
+        typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string',
+        typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string' && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0,
+        this.addedSpouse.updateNameDueToMarriageDocType.images !== undefined,
+        this.addedSpouse.updateNameDueToMarriageDocType.images !== null,
+        this.addedSpouse.updateNameDueToMarriageDocType.images && this.addedSpouse.updateNameDueToMarriageDocType.images.length > 0
+      );
+
+      if (this.addedSpouse.immigrationStatusChange === true) {
+        valid = valid && this.addedSpouse.livedInBCSinceBirth !== undefined
+        && this.addedSpouse.livedInBCSinceBirth !== null;
+
+        if (this.addedSpouse.livedInBCSinceBirth === false) {
+          // Check they inputted the province or country they came from
+          valid = valid && this.addedSpouse.movedFromProvinceOrCountry !== undefined
+          && this.addedSpouse.movedFromProvinceOrCountry !== null
+            && this.addedSpouse.movedFromProvinceOrCountry.length > 0
+            && this.addedSpouse.arrivalToBCDate !== undefined
+            && this.addedSpouse.arrivalToBCDate !== null;
+        }
+
+        console.log('inBC passes:', valid, this.addedSpouse.movedFromProvinceOrCountry !== undefined,
+          this.addedSpouse.movedFromProvinceOrCountry !== null,
+          typeof this.addedSpouse.movedFromProvinceOrCountry === 'string',
+          typeof this.addedSpouse.movedFromProvinceOrCountry === 'string' && this.addedSpouse.movedFromProvinceOrCountry.length > 0,
+          this.addedSpouse.arrivalToBCDate !== undefined,
+          this.addedSpouse.arrivalToBCDate !== null
+        );
+
+        valid = valid && this.addedSpouse.madePermanentMoveToBC !== undefined
+          && this.addedSpouse.madePermanentMoveToBC !== null;
+
+        valid = valid && this.addedSpouse.declarationForOutsideOver30Days !== undefined
+          && this.addedSpouse.declarationForOutsideOver30Days !== null;
+        console.log('Y/N declarations passes:', valid);
+
+        if (this.addedSpouse.declarationForOutsideOver30Days === true) {
+          valid = valid && this.addedSpouse.departureDateDuring12MonthsDate !== undefined
+            && this.addedSpouse.departureDateDuring12MonthsDate !== null;
+          valid = valid && this.addedSpouse.returnDateDuring12MonthsDate !== undefined
+            && this.addedSpouse.returnDateDuring12MonthsDate !== null;
+          valid = valid && this.addedSpouse.departureReason12Months !== undefined
+            && this.addedSpouse.departureReason12Months !== null;
+          valid = valid && this.addedSpouse.departureDestination12Months !== undefined
+            && this.addedSpouse.departureDestination12Months !== null;
+        }
+        console.log('over30passes:', valid);
+
+        valid = valid && this.addedSpouse.declarationForOutsideOver60Days !== undefined
+          && this.addedSpouse.declarationForOutsideOver60Days !== null;
+        if (this.addedSpouse.declarationForOutsideOver60Days === true) {
+          valid = valid && this.addedSpouse.departureDateDuring6MonthsDate !== undefined
+            && this.addedSpouse.departureDateDuring6MonthsDate !== null;
+          valid = valid && this.addedSpouse.returnDateDuring6MonthsDate !== undefined
+            && this.addedSpouse.returnDateDuring6MonthsDate !== null;
+          valid = valid && this.addedSpouse.departureReason !== undefined
+            && this.addedSpouse.departureReason !== null;
+          valid = valid && this.addedSpouse.departureDestination !== undefined
+            && this.addedSpouse.departureDestination !== null;
+        }
+        console.log('over60passes:', valid);
+
+        valid = valid && this.addedSpouse.hasBeenReleasedFromArmedForces !== undefined
+        && this.addedSpouse.hasBeenReleasedFromArmedForces !== null;
+        if (this.addedSpouse.hasBeenReleasedFromArmedForces === true) {
+          valid = valid && this.addedSpouse.dischargeDate !== undefined
+            && this.addedSpouse.dischargeDate !== null;
+          valid = valid && this.addedSpouse.nameOfInstitute !== undefined
+            && this.addedSpouse.nameOfInstitute !== null;
+        }
+        console.log('armedforces passes:', valid);
       }
     }
-
     return valid;
   }
 

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -130,7 +130,7 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
   }
 
   get showAddedSpouseBottomButtons(): boolean {
-    return this.accountApp.addedSpouse.immigrationStatusChange !== undefined && this.accountApp.addedSpouse.immigrationStatusChange !== false;
+    return this.accountApp.addedSpouse.immigrationStatusChange !== undefined;
   }
 
   get phns(): string[] {

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -130,7 +130,7 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
   }
 
   get showAddedSpouseBottomButtons(): boolean {
-    return this.accountApp.addedSpouse.immigrationStatusChange !== undefined;
+    return this.accountApp.addedSpouse.immigrationStatusChange !== undefined && this.accountApp.addedSpouse.immigrationStatusChange !== false;
   }
 
   get phns(): string[] {
@@ -143,34 +143,20 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
 
   checkAdd() {
     let valid = true;
+
+    // Don't bother checking if they aren't adding a spouse
     if (this.accountApp.hasSpouseAdded === true) {
-      // Checking radio buttons have been ticked
+      // Ticked "...active Medical Services Plan coverage?"
       valid = valid && this.addedSpouse.immigrationStatusChange !== undefined
         && this.addedSpouse.immigrationStatusChange !== null
+        // Ticked gender radio
         && this.addedSpouse.gender !== undefined
         && this.addedSpouse.gender !== null
+        // Ticked "Has your spouse's name changed due to marriage?"
         && this.addedSpouse.updateNameDueToMarriage !== undefined
         && this.addedSpouse.updateNameDueToMarriage !== null;
 
-        console.log('beginning passes:', valid);
-
-      if (this.addedSpouse.updateStatusInCanada === true) {
-        // Check that they have at least one document to support the status change
-        valid = valid && this.addedSpouse.updateStatusInCanadaDocType !== undefined
-          && this.addedSpouse.updateStatusInCanadaDocType !== null
-          && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined
-          && this.addedSpouse.updateStatusInCanadaDocType.images !== null
-          && this.addedSpouse.updateStatusInCanadaDocType.images.length > 0;
-      }
-
-      console.log(
-        'updateStatus passes',
-        valid,
-        this.addedSpouse.updateStatusInCanadaDocType !== null,
-        this.addedSpouse.updateStatusInCanadaDocType.images !== undefined,
-        this.addedSpouse.updateStatusInCanadaDocType.images !== null
-      );
-
+      // Ticked yes to name changed due to marriage
       if (this.addedSpouse.updateNameDueToMarriage === true) {
         // Check that they inputted a requested lastname and that they uploaded at least one supporting doc
         valid = valid && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined
@@ -183,78 +169,88 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
           && this.addedSpouse.updateNameDueToMarriageDocType.images.length > 0;
       }
 
-      console.log('updateName passes:', valid, this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined,
-        this.addedSpouse.updateNameDueToMarriageRequestedLastName !== null,
-        typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string',
-        typeof this.addedSpouse.updateNameDueToMarriageRequestedLastName === 'string' && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0,
-        this.addedSpouse.updateNameDueToMarriageDocType.images !== undefined,
-        this.addedSpouse.updateNameDueToMarriageDocType.images !== null,
-        this.addedSpouse.updateNameDueToMarriageDocType.images && this.addedSpouse.updateNameDueToMarriageDocType.images.length > 0
-      );
+      // If they don't have existing coverage
+      if (this.addedSpouse.immigrationStatusChange === false) {
+        // All radio buttons visible at this point have been ticked, and one update doc has been uploaded
+        valid = valid && this.addedSpouse.updateStatusInCanadaDocType !== undefined
+          && this.addedSpouse.updateStatusInCanadaDocType !== null
+          && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined
+          && this.addedSpouse.updateStatusInCanadaDocType.images !== null
+          && this.addedSpouse.updateStatusInCanadaDocType.images.length > 0
+          && this.addedSpouse.hasNameChange !== undefined
+          && this.addedSpouse.hasNameChange !== null
+          && this.addedSpouse.livedInBCSinceBirth !== undefined
+          && this.addedSpouse.livedInBCSinceBirth !== null
+          && this.addedSpouse.madePermanentMoveToBC !== undefined
+          && this.addedSpouse.madePermanentMoveToBC !== null
+          && this.addedSpouse.declarationForOutsideOver30Days !== undefined
+          && this.addedSpouse.declarationForOutsideOver30Days !== null
+          && this.addedSpouse.declarationForOutsideOver60Days !== undefined
+          && this.addedSpouse.declarationForOutsideOver60Days !== null
+          && this.addedSpouse.hasBeenReleasedFromArmedForces !== undefined
+          && this.addedSpouse.hasBeenReleasedFromArmedForces !== null;
 
-      if (this.addedSpouse.immigrationStatusChange === true) {
-        valid = valid && this.addedSpouse.livedInBCSinceBirth !== undefined
-        && this.addedSpouse.livedInBCSinceBirth !== null;
-
-        if (this.addedSpouse.livedInBCSinceBirth === false) {
-          // Check they inputted the province or country they came from
-          valid = valid && this.addedSpouse.movedFromProvinceOrCountry !== undefined
-          && this.addedSpouse.movedFromProvinceOrCountry !== null
-            && this.addedSpouse.movedFromProvinceOrCountry.length > 0
-            && this.addedSpouse.arrivalToBCDate !== undefined
-            && this.addedSpouse.arrivalToBCDate !== null;
+        // Yes to name change "due to legal name change"
+        if (this.addedSpouse.hasNameChange === true) {
+          valid = valid && this.addedSpouse.nameChangeDocs !== undefined
+            && this.addedSpouse.nameChangeDocs !== null
+            && this.addedSpouse.nameChangeDocs.images !== undefined
+            && this.addedSpouse.nameChangeDocs.images !== null
+            && this.addedSpouse.nameChangeDocs.images.length > 0
+            && this.addedSpouse.hasNameChangeAdditional !== undefined
+            && this.addedSpouse.hasNameChangeAdditional !== null;
+          // Yes to an additional document
+          if (this.addedSpouse.hasNameChangeAdditional === true) {
+            valid = valid && this.addedSpouse.nameChangeAdditionalDocs !== undefined
+              && this.addedSpouse.nameChangeAdditionalDocs !== null
+              && this.addedSpouse.nameChangeAdditionalDocs.images !== undefined
+              && this.addedSpouse.nameChangeAdditionalDocs.images !== null
+              && this.addedSpouse.nameChangeAdditionalDocs.images.length > 0;
+          }
         }
 
-        console.log('inBC passes:', valid, this.addedSpouse.movedFromProvinceOrCountry !== undefined,
-          this.addedSpouse.movedFromProvinceOrCountry !== null,
-          typeof this.addedSpouse.movedFromProvinceOrCountry === 'string',
-          typeof this.addedSpouse.movedFromProvinceOrCountry === 'string' && this.addedSpouse.movedFromProvinceOrCountry.length > 0,
-          this.addedSpouse.arrivalToBCDate !== undefined,
-          this.addedSpouse.arrivalToBCDate !== null
-        );
+        // No to "lived in BC since birth"
+        if (this.addedSpouse.livedInBCSinceBirth === false) {
+          // Check they inputted the province or country they came from and the date
+          valid = valid && this.addedSpouse.arrivalToBCDate !== undefined
+            && this.addedSpouse.arrivalToBCDate !== null
+            && this.addedSpouse.movedFromProvinceOrCountry !== undefined
+            && this.addedSpouse.movedFromProvinceOrCountry !== null
+            && typeof this.addedSpouse.movedFromProvinceOrCountry === 'string'
+            && this.addedSpouse.movedFromProvinceOrCountry.length > 0
+        }
 
-        valid = valid && this.addedSpouse.madePermanentMoveToBC !== undefined
-          && this.addedSpouse.madePermanentMoveToBC !== null;
-
-        valid = valid && this.addedSpouse.declarationForOutsideOver30Days !== undefined
-          && this.addedSpouse.declarationForOutsideOver30Days !== null;
-        console.log('Y/N declarations passes:', valid);
-
+        // Yes to "more than 30 days in the last 12 months"
         if (this.addedSpouse.declarationForOutsideOver30Days === true) {
           valid = valid && this.addedSpouse.departureDateDuring12MonthsDate !== undefined
-            && this.addedSpouse.departureDateDuring12MonthsDate !== null;
-          valid = valid && this.addedSpouse.returnDateDuring12MonthsDate !== undefined
-            && this.addedSpouse.returnDateDuring12MonthsDate !== null;
-          valid = valid && this.addedSpouse.departureReason12Months !== undefined
-            && this.addedSpouse.departureReason12Months !== null;
-          valid = valid && this.addedSpouse.departureDestination12Months !== undefined
+            && this.addedSpouse.departureDateDuring12MonthsDate !== null
+            && this.addedSpouse.returnDateDuring12MonthsDate !== undefined
+            && this.addedSpouse.returnDateDuring12MonthsDate !== null
+            && this.addedSpouse.departureReason12Months !== undefined
+            && this.addedSpouse.departureReason12Months !== null
+            && this.addedSpouse.departureDestination12Months !== undefined
             && this.addedSpouse.departureDestination12Months !== null;
         }
-        console.log('over30passes:', valid);
 
-        valid = valid && this.addedSpouse.declarationForOutsideOver60Days !== undefined
-          && this.addedSpouse.declarationForOutsideOver60Days !== null;
+        // Yes to "more than 30 days in the next 6 months"
         if (this.addedSpouse.declarationForOutsideOver60Days === true) {
           valid = valid && this.addedSpouse.departureDateDuring6MonthsDate !== undefined
-            && this.addedSpouse.departureDateDuring6MonthsDate !== null;
-          valid = valid && this.addedSpouse.returnDateDuring6MonthsDate !== undefined
-            && this.addedSpouse.returnDateDuring6MonthsDate !== null;
-          valid = valid && this.addedSpouse.departureReason !== undefined
-            && this.addedSpouse.departureReason !== null;
-          valid = valid && this.addedSpouse.departureDestination !== undefined
+            && this.addedSpouse.departureDateDuring6MonthsDate !== null
+            && this.addedSpouse.returnDateDuring6MonthsDate !== undefined
+            && this.addedSpouse.returnDateDuring6MonthsDate !== null
+            && this.addedSpouse.departureReason !== undefined
+            && this.addedSpouse.departureReason !== null
+            && this.addedSpouse.departureDestination !== undefined
             && this.addedSpouse.departureDestination !== null;
         }
-        console.log('over60passes:', valid);
 
-        valid = valid && this.addedSpouse.hasBeenReleasedFromArmedForces !== undefined
-        && this.addedSpouse.hasBeenReleasedFromArmedForces !== null;
+        // Yes to "released from Canadian Armed Forces"
         if (this.addedSpouse.hasBeenReleasedFromArmedForces === true) {
           valid = valid && this.addedSpouse.dischargeDate !== undefined
-            && this.addedSpouse.dischargeDate !== null;
-          valid = valid && this.addedSpouse.nameOfInstitute !== undefined
+            && this.addedSpouse.dischargeDate !== null
+            && this.addedSpouse.nameOfInstitute !== undefined
             && this.addedSpouse.nameOfInstitute !== null;
         }
-        console.log('armedforces passes:', valid);
       }
     }
     return valid;

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -144,19 +144,44 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
   checkAdd() {
     let valid = true;
     if (this.accountApp.hasSpouseAdded === true) {
-      valid = valid && this.addedSpouse.immigrationStatusChange !== undefined;
+      // Checking radio buttons have been ticked
+      valid = valid && this.addedSpouse.immigrationStatusChange !== undefined
+        && this.addedSpouse.immigrationStatusChange != null
+        && this.addedSpouse.gender !== undefined
+        && this.addedSpouse.gender != null
+        && this.addedSpouse.updateNameDueToMarriage !== undefined
+        && this.addedSpouse.updateNameDueToMarriage != null
+        && this.addedSpouse.hasNameChange !== undefined
+        && this.addedSpouse.hasNameChange != null;
+
+      if (this.addedSpouse.updateStatusInCanada === true) {
+        // Check that they have at least one document to support the status change
+        valid = valid && this.addedSpouse.updateStatusInCanadaDocType !== undefined
+          && this.addedSpouse.updateStatusInCanadaDocType != null
+          && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined
+          && this.addedSpouse.updateStatusInCanadaDocType.images !== null
+          && this.addedSpouse.updateStatusInCanadaDocType.images.length > 0;
+      }
+
+      if (this.addedSpouse.updateNameDueToMarriage === true) {
+        // Check that they inputted a requested lastname and that they uploaded at least one supporting doc
+        valid = valid && this.addedSpouse.updateNameDueToMarriageRequestedLastName !== undefined
+          && this.addedSpouse.updateNameDueToMarriageRequestedLastName != null
+          && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0
+          && this.addedSpouse.updateNameDueToMarriageRequestedLastName.match(/\d+/g) === null
+          && this.addedSpouse.nameChangeDocs.images !== undefined
+          && this.addedSpouse.nameChangeDocs.images != null
+          && this.addedSpouse.nameChangeDocs.images.length > 0;
+      }
+
+      if (this.addedSpouse.livedInBCSinceBirth === false) {
+        // Check they inputted the province or country they came from
+        valid = valid && this.addedSpouse.movedFromProvinceOrCountry !== undefined
+          && this.addedSpouse.movedFromProvinceOrCountry != null
+          && this.addedSpouse.movedFromProvinceOrCountry.length > 0;
+      }
     }
-    valid = valid && this.addedSpouse.gender !== undefined
-      && this.addedSpouse.updateNameDueToMarriage !== undefined;
-    if (this.addedSpouse.updateStatusInCanada === true) {
-      valid = valid && this.addedSpouse.updateStatusInCanadaDocType.images !== undefined;
-    }
-    if (this.addedSpouse.updateNameDueToMarriage === true) {
-      valid = valid && this.addedSpouse.updateNameDueToMarriageRequestedLastName
-        && this.addedSpouse.updateNameDueToMarriageRequestedLastName.length > 0
-        && this.addedSpouse.updateNameDueToMarriageRequestedLastName.match(/\d+/g) === null
-        && this.addedSpouse.nameChangeDocs.images.length > 0;
-    }
+
     return valid;
   }
 


### PR DESCRIPTION
This is for the Spouse Info page.

What I did:
1) Changed validation from just being falsy or truthy to not undefined
and not null, for any odd cases where the value gets reset to null etc.
2) Added checks for arrays/objects before the length of content of them
was validated. Eg:
Instead of:
`if (some property of the object exists)`
I put:
`if (the object exists && some property of the object exists)`
3) Added validation for the "From (province or country)" field
4) Removed a comment in moving-information that is no longer needed

Could still use more validation