### PR TITLE
DEAM-351: Upload failure alerts

### DIFF
--- a/src/app/modules/msp-core/components/support-documents/support-documents.component.html
+++ b/src/app/modules/msp-core/components/support-documents/support-documents.component.html
@@ -50,11 +50,12 @@
       [(images)]="documents"
       id="docUploader_{{objectId}}"
       [required]="true"
-      instructionText="{{uploadInstructions}}">
+      instructionText="{{uploadInstructions}}"
+      (errorDocument)="handleSupportDocError($event)">
     </common-file-uploader>
     <common-error-container
-      [displayError]="checkDuplicateDocs()">
-      Uploading the same document is not allowed.
+      [displayError]="supportDocError !== null">
+      {{ supportDocErrorMsg }}
     </common-error-container>
     <ng-content select="[requestAdditionInfo]"></ng-content>
     <aside>

--- a/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
+++ b/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
@@ -9,7 +9,7 @@ import {
   OnChanges,
   OnDestroy,
 } from '@angular/core';
-import { Base, CommonImage, SampleImageInterface } from 'moh-common-lib';
+import { Base, CommonImage, SampleImageInterface, CommonImageError } from 'moh-common-lib';
 import {
   CanadianStatusReason,
   StatusInCanada,
@@ -22,6 +22,8 @@ import {
 import { ControlContainer, NgForm } from '@angular/forms';
 import { BehaviorSubject } from 'rxjs';
 import { SupportDocuments } from '../../models/support-documents.model';
+import { MspLogService } from '../../../../services/log.service';
+
 
 export function suportDocumentRules(
   status: StatusInCanada,
@@ -151,30 +153,26 @@ export class SupportDocumentsComponent extends Base
   @Input() statusReason: CanadianStatusReason;
   // Toggles display for the 'Add' button (true => button is displayed, false => no button displayed)
   @Input() displayButton: boolean = false;
-
   @Input() supportDoc: SupportDocuments;
-  @Output() supportDocChange: EventEmitter<SupportDocuments> = new EventEmitter<
-    SupportDocuments
-  >();
+  @Output() supportDocChange: EventEmitter<SupportDocuments> = new EventEmitter<SupportDocuments>();
 
   uploadInstructions = 'Click add, or drag and drop a file into this box';
-
   btnEnabled: boolean = true;
   availableSupportDocuments: string[] = [];
-
   onChanges = new BehaviorSubject<SimpleChanges>(null);
-
   docSampleImages: SampleImageInterface[] = [];
-  newImage: CommonImage[];
 
   // List of all supporting document types
   private _documentOpts: string[] = Object.keys(SupportDocumentList).map(
     x => SupportDocumentList[x]
   );
 
-  constructor() {
+  constructor(private logService: MspLogService) {
     super();
   }
+
+  _supportDocError: CommonImage = null;
+  _supportDocErrorMsg: string = '';
 
   ngOnInit() {
     if (this.supportDoc.documentType && this.displayButton) {
@@ -208,22 +206,87 @@ export class SupportDocumentsComponent extends Base
     });
   }
 
-  checkDuplicateDocs() {
-    if (this.supportDoc.images) {
-      for (let i = 0; i < this.supportDoc.images.length; i++) {
-        if (this.newImage) {
-          return (
-            this.supportDoc.images[i].fileContent ===
-            this.newImage[0].fileContent
-          );
-        }
+  // Set the error obj and appropriate msg
+  handleSupportDocError(error: CommonImage) {
+    if (error) {
+      switch (error.error) {
+        case CommonImageError.WrongType:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That is the wrong type of attachment to submit.';
+          break;
+        case CommonImageError.TooSmall:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That attachment is too small, please upload a larger attachment.';
+          break;
+        case CommonImageError.TooBig:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That attachment is too big, please upload a smaller attachment.';
+          break;
+        case CommonImageError.AlreadyExists:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That attachment has already been uploaded.';
+          break;
+        case CommonImageError.Unknown:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'The upload failed, please try again. If the issue persists, please upload a different attachment.';
+          break;
+        case CommonImageError.CannotOpen:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That attachment cannot be opened, please upload a different attachment.';
+          break;
+        case CommonImageError.PDFnotSupported:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That PDF type is not supported, please upload a different attachment.';
+          break;
+        case CommonImageError.CannotOpenPDF:
+          this.supportDocError = error;
+          this.supportDocErrorMsg = 'That PDF cannot be opened, please upload a different attachment.';
+          break;
+        default:
+          this.supportDocError = null;
+          this.supportDocErrorMsg = '';
+          break;
       }
     }
-    return false;
   }
 
   ngOnChanges(changes: SimpleChanges) {
     this.onChanges.next(changes);
+  }
+
+  get supportDocError() {
+    return this._supportDocError;
+  }
+
+  set supportDocError(error) {
+    // If the error objects exists and it's enum is defined
+    if (error && error.error !== undefined && error.error !== null) {
+      this._supportDocError = error;
+      // TODO: Confirm Splunk usage is ok for this, and how the log should be structured
+      // this.logService.log({ date: new Date(), error}, 'Request method here');
+    } else {
+      // Remove both the error object and the current message, as there is no longer an error
+      this._supportDocError = null;
+      this._supportDocErrorMsg = '';
+    }
+  }
+
+  get supportDocErrorMsg() {
+    // If we have an error object and the enum is defined
+    if (this.supportDocError && this.supportDocError.error !== null && this.supportDocError.error !== undefined) {
+      // return the message
+      return this._supportDocErrorMsg;
+    }
+    return '';
+  }
+
+  set supportDocErrorMsg(msg) {
+    // Just incase someone tries to set the msg to something that isn't a string
+    if (typeof msg === 'string') {
+      this._supportDocErrorMsg = msg;
+    } else {
+      this._supportDocErrorMsg = '';
+    }
   }
 
   ngOnDestroy() {
@@ -231,7 +294,7 @@ export class SupportDocumentsComponent extends Base
   }
 
   get hasDocumentType() {
-    return this.supportDoc.documentType ? true : false;
+    return this.supportDoc && this.supportDoc.documentType ? true : false;
   }
 
   // When clicked button is disabled
@@ -249,7 +312,6 @@ export class SupportDocumentsComponent extends Base
 
   removeDocument() {
     this.btnEnabled = true;
-
     this.supportDoc.images = [];
     this.supportDoc.documentType = null;
     this.supportDocChange.emit(this.supportDoc);
@@ -299,6 +361,8 @@ export class SupportDocumentsComponent extends Base
   }
 
   set documents(images: CommonImage[]) {
+    // When a new doc is uploaded, remove the current error before checking again
+    this.supportDocError = null;
     this.supportDoc.images = images;
     this.supportDocChange.emit(this.supportDoc);
   }


### PR DESCRIPTION
This is a bit of a verbose message but this component is used in
multiple places and it seems like it's an urgent feature, so I don't
want to miss anything

What I did:
1) Made use of errorDocument emitter in common-file-uploader
2) Replaced checkDuplicateDocs and newImage with supportDocError
(getter + setter), supportDocErrorMsg (getter + setter), and
handleSupportDocError.
3) Use enums to dictate which messages to dynamically show

Tried across IE, Chrome, etc. and in different combinations. The
remaining situations it doesn't handle well already exist in the
current version, and those is the following:
1) If you attempt to upload a filetype that isn't one of the expected
ones (.otf for example) it will show the error as expected, but
subsequent correct uploads will not run. For some reason it stops at
`opening file dialog` in the common-file-uploader component. The issue
goes away when you rerender the component (by unchecking and rechecking
the relevant update checkbox)

2) It is limited to 50 pages for PDFs (makes sense if youre only upload
IDs and short forms) but will cut off longer PDFs without notifying the
user. It also takes long enough that the user may assume it's broken.
I intend to add a loading spinner for this as well as a restyle.

To test:
1) Click the add button and upload a proper doc
2) Click the add button and upload the same doc again. There should be
an appropriate error (see attached)
3) Click remove to remove the current doc, the error should go away
4) Add another valid document, then without removing the first doc, 
add a different kind of valid doc (like a multipage PDF etc) and make
sure that passes as well (you may have to wait a while depending on
how many pages there are)

![upload_fail_alert](https://user-images.githubusercontent.com/32586431/87656765-c5c96080-c70e-11ea-9d63-f34f4b5c378e.PNG)