### PR TITLE
DEAM-363: Get spouse Can Forces info to payload

### DIFF
--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -827,7 +827,7 @@ export class MspApiAccountService extends AbstractHttpService {
       to.willBeAway.armedDischargeDate = format(
         from.dischargeDate,
         this.ISO8601DateFormat
-        );
+      );
       to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
       to.willBeAway.isFullTimeStudent = from.relationship === Relationship.Child19To24 ? 'Y' : 'N';
     }
@@ -1012,7 +1012,7 @@ export class MspApiAccountService extends AbstractHttpService {
       to.willBeAway.armedDischargeDate = format(
         from.dischargeDate,
         this.ISO8601DateFormat
-        );
+      );
       to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
       to.willBeAway.isFullTimeStudent = from.relationship === Relationship.Child19To24 ? 'Y' : 'N';
     }

--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -822,6 +822,16 @@ export class MspApiAccountService extends AbstractHttpService {
       to.mailingAddress = this.convertAddress(from.mailingAddress);
     }
 
+    if (from.hasDischarge) {
+      to.willBeAway = WillBeAwayTypeFactory.make();
+      to.willBeAway.armedDischargeDate = format(
+        from.dischargeDate,
+        this.ISO8601DateFormat
+        );
+      to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
+      to.willBeAway.isFullTimeStudent = from.relationship === Relationship.Child19To24 ? 'Y' : 'N';
+    }
+
     return to;
   }
 
@@ -996,6 +1006,17 @@ export class MspApiAccountService extends AbstractHttpService {
     } else if (from.knownMailingAddress === false) {
       to.mailingAddress = this.unknownAddress();
     }
+
+    if (from.hasDischarge) {
+      to.willBeAway = WillBeAwayTypeFactory.make();
+      to.willBeAway.armedDischargeDate = format(
+        from.dischargeDate,
+        this.ISO8601DateFormat
+        );
+      to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
+      to.willBeAway.isFullTimeStudent = from.relationship === Relationship.Child19To24 ? 'Y' : 'N';
+    }
+
     return to;
   }
 
@@ -1138,17 +1159,6 @@ export class MspApiAccountService extends AbstractHttpService {
           from.planOnBeingOutOfBCRecord.location;
       }
     }
-
-    // Have they been released from the Canadian Armed Forces or an Institution?
-    if (from.hasDischarge) {
-      to.willBeAway = WillBeAwayTypeFactory.make();
-      to.willBeAway.armedDischargeDate = format(
-        from.dischargeDate,
-        this.ISO8601DateFormat
-      );
-      to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
-      to.willBeAway.isFullTimeStudent = 'N';
-    }
   }
 
   private populateNewBeneficiaryDetailsForSpouse(
@@ -1232,17 +1242,6 @@ export class MspApiAccountService extends AbstractHttpService {
         to.outsideBCinFuture.destination =
           from.planOnBeingOutOfBCRecord.location;
       }
-    }
-
-    // Have they been released from the Canadian Armed Forces or an Institution?
-    if (from.hasDischarge) {
-      to.willBeAway = WillBeAwayTypeFactory.make();
-      to.willBeAway.armedDischargeDate = format(
-        from.dischargeDate,
-        this.ISO8601DateFormat
-      );
-      to.willBeAway.armedForceInstitutionName = from.nameOfInstitute;
-      to.willBeAway.isFullTimeStudent = 'N';
     }
   }
 


### PR DESCRIPTION
Please review when convenient

What I did:
1) Move willBeAway stuff out of populateBeneficiary methods and into
the main convert methods.
2) Changed the expression that got evaluated for the fullTimeStudent
property. Formerly it was just N if you were ever discharged. Now it's
if the relationship is 19-24 (has to be a fulltime student in that case)

JSON output for adding child and spouse both discharge attached:
[AddChildAddSpouseDischarge.zip](https://github.com/bcgov/MyGovBC-MSP/files/4936676/AddChildAddSpouseDischarge.zip)
