### PR TITLE
DEAM-349: Get sp+ch mailingAddress info to payload

### DIFF
--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -820,8 +820,6 @@ export class MspApiAccountService extends AbstractHttpService {
       from.mailingAddress.postal
     ) {
       to.mailingAddress = this.convertAddress(from.mailingAddress);
-    } else {
-      to.mailingAddress = this.unknownAddress();
     }
 
     return to;
@@ -1002,8 +1000,6 @@ export class MspApiAccountService extends AbstractHttpService {
       from.mailingAddress.postal
     ) {
       to.mailingAddress = this.convertAddress(from.mailingAddress);
-    } else {
-      to.mailingAddress = this.unknownAddress();
     }
 
     return to;
@@ -1499,8 +1495,6 @@ export class MspApiAccountService extends AbstractHttpService {
       accountHolder.residenceAddress = this.convertAddress(
         from.residentialAddress
       );
-    } else {
-      accountHolder.residenceAddress = this.unknownAddress();
     }
 
     // If mailing is same as residential address, use residential address as the mailing adress.

--- a/src/app/modules/account/services/msp-api-account.service.ts
+++ b/src/app/modules/account/services/msp-api-account.service.ts
@@ -820,6 +820,8 @@ export class MspApiAccountService extends AbstractHttpService {
       from.mailingAddress.postal
     ) {
       to.mailingAddress = this.convertAddress(from.mailingAddress);
+    } else {
+      to.mailingAddress = this.unknownAddress();
     }
 
     return to;
@@ -991,11 +993,19 @@ export class MspApiAccountService extends AbstractHttpService {
       }
     }
 
-    if (from.knownMailingAddress === true) {
+    if (
+      from.mailingAddress &&
+      from.mailingAddress.addressLine1 &&
+      from.mailingAddress.city &&
+      from.mailingAddress.province &&
+      from.mailingAddress.country &&
+      from.mailingAddress.postal
+    ) {
       to.mailingAddress = this.convertAddress(from.mailingAddress);
-    } else if (from.knownMailingAddress === false) {
+    } else {
       to.mailingAddress = this.unknownAddress();
     }
+
     return to;
   }
 


### PR DESCRIPTION
Please review when convenient

What I did:
1) Fix the validation for mailing addresses for children
2) Use the unknownAddress method to fill in missing info where 
appropriate

Attached is two payloads, one of them is a remove child and remove
spouse submitting with proper mailing address info, and the other is a
removed spouse with an unknown address being filled in properly
[address_payloads.zip](https://github.com/bcgov/MyGovBC-MSP/files/4936801/address_payloads.zip)
