### PR TITLE
DEAM-380: Fix discharge date affecting birthdate

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.ts
+++ b/src/app/modules/account/components/moving-information/moving-information.component.ts
@@ -7,6 +7,7 @@ import { Relationship } from 'app/models/relationship.enum';
 import { MspPerson } from '../../../../components/msp/model/msp-person.model';
 import { formatDateField } from '../../helpers/date';
 import { isBefore, subDays, addDays, addMonths } from 'date-fns';
+import * as _ from "lodash";
 
 // TO BE removed - differenece need to be added to msp-core moving-info so that it will work with account
 @Component({
@@ -176,8 +177,8 @@ export class ChildMovingInformationComponent extends Base implements OnInit {
   }
 
   get startDischargeDate() {
-    if (this.person.dateOfBirth){
-      const startDate = this.person.dateOfBirth;
+    if (this.person.dateOfBirth) {
+      const startDate = _.cloneDeep(this.person.dateOfBirth);
       startDate.setDate(this.person.dateOfBirth.getDate() + 1);
       return startDate;
     }


### PR DESCRIPTION
Please review when convenient

What I did:
1) Import lodash and make a deep copy of the date object being used so
operations on the copy didn't affect the original

See attached screenshots and note the console in both. Birthdate was
being incremented every time discharge date was touched

>## Broken:
![discharge-birthday-broken](https://user-images.githubusercontent.com/32586431/88087776-4d173980-cb3e-11ea-944b-50eaf2bc4587.PNG)

>## Fixed:
![discharge-birthday-fixed](https://user-images.githubusercontent.com/32586431/88087783-4dafd000-cb3e-11ea-8c79-e3e9828358aa.PNG)

