### PR TITLE
DEAM-388: Fix errors on sending page

### DIFF
--- a/src/app/modules/account/pages/authorize/authorize.component.html
+++ b/src/app/modules/account/pages/authorize/authorize.component.html
@@ -27,12 +27,19 @@
       <div class="strong"
         [innerHTML]="questionApplicant">
       </div>
-      <div class="form-check form-check-inline mb-5">
-        <common-checkbox
-          [label]="lang('./en/index.js').agreeLabel"
-          (dataChange)="applicantAuthorizeOnChange($event)"
-          [data]="mspAccountApp.authorizedByApplicant">
-        </common-checkbox>
+      <div class="form mb-5">
+        <div class="form-check form-check-inline">
+          <common-checkbox
+            name="authorizedByApplicant"
+            [label]="lang('./en/index.js').agreeLabel"
+            (dataChange)="applicantAuthorizeOnChange($event)"
+            [data]="mspAccountApp.authorizedByApplicant"
+            [required]="true">
+          </common-checkbox>
+        </div>
+        <common-error-container [displayError]="showUnauthorizedError && !mspAccountApp.authorizedByApplicant">
+          Field is required.
+        </common-error-container>
       </div>
       <div class="row">
         <div class="col-lg-12">

--- a/src/app/modules/account/pages/authorize/authorize.component.scss
+++ b/src/app/modules/account/pages/authorize/authorize.component.scss
@@ -1,0 +1,4 @@
+common-checkbox[name="authorizedByApplicant"] {
+  display: flex;
+  align-items: center;
+}

--- a/src/app/modules/account/pages/authorize/authorize.component.ts
+++ b/src/app/modules/account/pages/authorize/authorize.component.ts
@@ -20,6 +20,7 @@ export class AuthorizeComponent extends BaseForm implements OnInit {
   mspAccountApp: MspAccountApp;
   captchaApiBaseUrl: string;
   @ViewChild(NgForm) form: NgForm;
+  _showUnauthorizedError: boolean = false;
 
   constructor(private dataService: MspAccountMaintenanceDataService,
               private _router: Router,
@@ -28,6 +29,14 @@ export class AuthorizeComponent extends BaseForm implements OnInit {
       super(_router, containerService, pageStateService);
       this.mspAccountApp = dataService.getMspAccountApp();
       this.captchaApiBaseUrl = environment.appConstants.captchaApiBaseUrl;
+  }
+
+  get showUnauthorizedError() {
+    return this._showUnauthorizedError;
+  }
+
+  set showUnauthorizedError(val: boolean) {
+    this._showUnauthorizedError = val;
   }
 
   // unused.. logic changed
@@ -87,11 +96,13 @@ export class AuthorizeComponent extends BaseForm implements OnInit {
   handleFormSubmission($event) {}
 
   continue(): void {
-    if (!this.canContinue()) {
+    if (!this.canContinue() || !this.mspAccountApp.authorizedByApplicant) {
       console.log('Please fill in all required fields on the form.');
       this.markAllInputsTouched();
+      this.showUnauthorizedError = true;
       return;
     }
+    this.showUnauthorizedError = false;
     this.navigate('/deam/sending');
   }
 }


### PR DESCRIPTION
Please review when convenient

What:

1) Align the checkbox and label
2) Add a displayed error when they try to submit without it
3) Stop the submission from being sent without authorization

>### Before:
User clicks submit without checking the box or the captcha
![old_auth_errors](https://user-images.githubusercontent.com/32586431/88490514-fdc37580-cf50-11ea-8ca1-0aa51c53a6c0.PNG)
User clicks submit with captcha but without checking the box (no longer happens)
![old_auth_nocheckbox](https://user-images.githubusercontent.com/32586431/88490515-fe5c0c00-cf50-11ea-9e1e-8b06b86e5abf.PNG)

>### After:
![new_auth_errors](https://user-images.githubusercontent.com/32586431/88490512-fd2adf00-cf50-11ea-9c09-bc9eff8cb936.PNG)