### PR TITLE
DEAM-272: Date errors gone, sub error still (WIP)

### DIFF
--- a/src/app/components/msp/model/msp-person.dto.ts
+++ b/src/app/components/msp/model/msp-person.dto.ts
@@ -38,6 +38,8 @@ export class PersonDto {
     departureDateDuring6MonthsDate: Date;
     returnDate12MonthsDate: Date;
     returnDate6MonthsDate: Date;
+    returnDateDuring12MonthsDate: Date;
+    returnDateDuring6MonthsDate: Date;
 
     hasBeenReleasedFromArmedForces: boolean;
     movedFromProvinceOrCountry: string;

--- a/src/app/modules/account/services/msp-account-data.service.ts
+++ b/src/app/modules/account/services/msp-account-data.service.ts
@@ -53,6 +53,7 @@ export class MspAccountMaintenanceDataService {
   }
 
   private fetchMspAccountApplication(): MspAccountApp {
+    console.log('fetchMspAccount ran');
     const dto: MspAccountDto = this.localStorageService.get<MspAccountDto>(
       this.mspAccountStorageKey
     );
@@ -109,6 +110,7 @@ export class MspAccountMaintenanceDataService {
   }
 
   private toPersonDtoForAccount(input: MspPerson): PersonDto {
+    console.log('toPersonDtaForAccount ran');
     const dto: PersonDto = new PersonDto();
 
     dto.id = input.id;
@@ -219,8 +221,8 @@ export class MspAccountMaintenanceDataService {
 
     dto.departureDateDuring12MonthsDate =  input.departureDateDuring12MonthsDate;
     dto.departureDateDuring6MonthsDate = input.departureDateDuring6MonthsDate;
-    dto.returnDate12MonthsDate = input.returnDate12MonthsDate ;
-    dto.returnDate6MonthsDate = input.returnDate6MonthsDate ;
+    dto.returnDateDuring12MonthsDate = input.returnDateDuring12MonthsDate ;
+    dto.returnDateDuring6MonthsDate = input.returnDateDuring6MonthsDate ;
 
     dto.immigrationStatusChange = input.immigrationStatusChange;
    // dto.spouseRemoved = input.spouseRemoved;
@@ -246,6 +248,7 @@ export class MspAccountMaintenanceDataService {
   }
 
   private fromPersonDtoForAccount(dto: PersonDto): MspPerson {
+    console.log('fromPersonDtoForAccount ran');
     const output: MspPerson = new MspPerson(dto.relationship);
 
     output.id = dto.id;
@@ -258,7 +261,7 @@ export class MspAccountMaintenanceDataService {
     output.firstName = dto.firstName;
     output.middleName = dto.middleName;
     output.lastName = dto.lastName;
-    output.dob = dto.dob;
+    output.dob = new Date(dto.dob);
     output.middleName = dto.middleName;
     output.healthNumberFromOtherProvince = dto.healthNumberFromOtherProvince;
     output.previous_phn = dto.previous_phn;
@@ -275,32 +278,32 @@ export class MspAccountMaintenanceDataService {
     output.updatingPersonalInfo = dto.updatingPersonalInfo;
     output.departureDestination = dto.departureDestination;
 
-    output.cancellationDate = dto.cancellationDate;
+    output.cancellationDate = new Date(dto.cancellationDate);
     output.cancellationReason = dto.cancellationReason;
     output.hasCurrentMailingAddress = dto.hasCurrentMailingAddress;
     output.removedSpouseDueToDivorceDoc = dto.removedSpouseDueToDivorceDoc;
 
     output.isRemovedAtTheEndOfCurrentMonth = dto.isRemovedAtTheEndOfCurrentMonth;
 
-    output.marriageDate  = dto.marriageDate;
+    output.marriageDate  = new Date(dto.marriageDate);
 
     output.hasActiveMedicalServicePlan = dto.hasActiveMedicalServicePlan;
 
-    output.arrivalToCanadaDate = dto.arrivalToCanadaDate;
-    output.arrivalToBCDate = dto.arrivalToBCDate;
+    output.arrivalToCanadaDate = new Date(dto.arrivalToCanadaDate);
+    output.arrivalToBCDate = new Date(dto.arrivalToBCDate);
 
     output.movedFromProvinceOrCountry = dto.movedFromProvinceOrCountry;
     output.hasBeenReleasedFromArmedForces = dto.hasBeenReleasedFromArmedForces;
     output.institutionWorkHistory = dto.institutionWorkHistory;
-    output.dischargeDate = dto.dischargeDate;
+    output.dischargeDate = new Date(dto.dischargeDate);
 
     output.fullTimeStudent = dto.fullTimeStudent;
     output.inBCafterStudies = dto.inBCafterStudies;
 
     output.schoolName = dto.schoolName;
-    output.studiesDepartureDate = dto.studiesDepartureDate;
-    output.studiesFinishedDate = dto.studiesFinishedDate;
-    output.studiesBeginDate = dto.studiesBeginDate;
+    output.studiesDepartureDate = new Date(dto.studiesDepartureDate);
+    output.studiesFinishedDate = new Date(dto.studiesFinishedDate);
+    output.studiesBeginDate = new Date(dto.studiesBeginDate);
 
     output.schoolOutsideOfBC = dto.schoolOutsideOfBC;
 
@@ -311,7 +314,7 @@ export class MspAccountMaintenanceDataService {
       dto.declarationForOutsideOver60Days;
 
     output.newlyAdopted = dto.newlyAdopted;
-    output.adoptedDate = dto.adoptedDate;
+    output.adoptedDate = new Date(dto.adoptedDate);
 
     output.reasonForCancellation = dto.reasonForCancellation;
     output.prevLastName = dto.prevLastName;
@@ -326,18 +329,14 @@ export class MspAccountMaintenanceDataService {
     output.departureReason = dto.departureReason;
     output.departureReason12Months = dto.departureReason12Months;
     output.departureDestination12Months = dto.departureDestination12Months;
-    output.departureDateDuring12MonthsDate =  dto.departureDateDuring12MonthsDate;
-    output.departureDateDuring6MonthsDate = dto.departureDateDuring6MonthsDate ;
-
-    output.returnDate12MonthsDate = dto.returnDate12MonthsDate ;
-
-    output.returnDate6MonthsDate = dto.returnDate6MonthsDate ;
+    output.departureDateDuring12MonthsDate = new Date(dto.departureDateDuring12MonthsDate);
+    output.departureDateDuring6MonthsDate = new Date(dto.departureDateDuring6MonthsDate);
+    output.returnDateDuring12MonthsDate = new Date(dto.returnDateDuring12MonthsDate);
+    output.returnDateDuring6MonthsDate = dto.returnDateDuring6MonthsDate;
     output.nameOfInstitute = dto.nameOfInstitute;
 
 
-
-
-    output.cancellationDate = dto.cancellationDate;
+    output.cancellationDate = new Date(dto.cancellationDate);
     if (dto.gender) {
       output.gender = dto.gender;
     }
@@ -387,6 +386,7 @@ export class MspAccountMaintenanceDataService {
   }
 
   toMspAccountAppTransferObject(input: MspAccountApp): MspAccountDto {
+    console.log('toMspAccountAppTransferObject ran');
     const dto: MspAccountDto = new MspAccountDto();
     dto.addressUpdate = input.accountChangeOptions.addressUpdate;
 
@@ -457,6 +457,7 @@ export class MspAccountMaintenanceDataService {
 
 
   private toOutofBCRecordDto(outofBCRecord: OutofBCRecord) {
+    console.log('toOutofBCRecordDto ran');
     if (outofBCRecord == null) return null;
 
     const dto: OutofBCRecordDto = new OutofBCRecordDto();
@@ -468,17 +469,19 @@ export class MspAccountMaintenanceDataService {
   }
 
   private toOutofBCRecord(dto: OutofBCRecordDto) {
+    console.log('toOutofBCRecord ran');
     if (dto == null) return null;
 
     const rec: OutofBCRecord = new OutofBCRecord();
     rec.reason = dto.reason;
     rec.location = dto.location;
-    rec.departureDate = dto.departureDate;
-    rec.returnDate = dto.returnDate;
+    rec.departureDate = new Date(dto.departureDate);
+    rec.returnDate = new Date(dto.returnDate);
     return rec;
   }
 
   private fromMspAccountTransferObject(dto: MspAccountDto): MspAccountApp {
+    console.log('fromMspAccountTransferObject ran');
     const output: MspAccountApp = new MspAccountApp();
 
     output.accountChangeOptions.addressUpdate = dto.addressUpdate;

--- a/src/app/modules/account/services/msp-account-data.service.ts
+++ b/src/app/modules/account/services/msp-account-data.service.ts
@@ -53,7 +53,6 @@ export class MspAccountMaintenanceDataService {
   }
 
   private fetchMspAccountApplication(): MspAccountApp {
-    console.log('fetchMspAccount ran');
     const dto: MspAccountDto = this.localStorageService.get<MspAccountDto>(
       this.mspAccountStorageKey
     );
@@ -110,7 +109,6 @@ export class MspAccountMaintenanceDataService {
   }
 
   private toPersonDtoForAccount(input: MspPerson): PersonDto {
-    console.log('toPersonDtaForAccount ran');
     const dto: PersonDto = new PersonDto();
 
     dto.id = input.id;
@@ -248,7 +246,6 @@ export class MspAccountMaintenanceDataService {
   }
 
   private fromPersonDtoForAccount(dto: PersonDto): MspPerson {
-    console.log('fromPersonDtoForAccount ran');
     const output: MspPerson = new MspPerson(dto.relationship);
 
     output.id = dto.id;
@@ -261,7 +258,7 @@ export class MspAccountMaintenanceDataService {
     output.firstName = dto.firstName;
     output.middleName = dto.middleName;
     output.lastName = dto.lastName;
-    output.dob = new Date(dto.dob);
+    output.dob = dto.dob ? new Date(dto.dob) : undefined;
     output.middleName = dto.middleName;
     output.healthNumberFromOtherProvince = dto.healthNumberFromOtherProvince;
     output.previous_phn = dto.previous_phn;
@@ -278,32 +275,32 @@ export class MspAccountMaintenanceDataService {
     output.updatingPersonalInfo = dto.updatingPersonalInfo;
     output.departureDestination = dto.departureDestination;
 
-    output.cancellationDate = new Date(dto.cancellationDate);
+    output.cancellationDate = dto.cancellationDate ? new Date(dto.cancellationDate) : undefined;
     output.cancellationReason = dto.cancellationReason;
     output.hasCurrentMailingAddress = dto.hasCurrentMailingAddress;
     output.removedSpouseDueToDivorceDoc = dto.removedSpouseDueToDivorceDoc;
 
     output.isRemovedAtTheEndOfCurrentMonth = dto.isRemovedAtTheEndOfCurrentMonth;
 
-    output.marriageDate  = new Date(dto.marriageDate);
+    output.marriageDate = dto.cancellationDate ? new Date(dto.marriageDate): undefined;
 
     output.hasActiveMedicalServicePlan = dto.hasActiveMedicalServicePlan;
 
-    output.arrivalToCanadaDate = new Date(dto.arrivalToCanadaDate);
-    output.arrivalToBCDate = new Date(dto.arrivalToBCDate);
+    output.arrivalToCanadaDate = dto.arrivalToCanadaDate ? new Date(dto.arrivalToCanadaDate) : undefined;
+    output.arrivalToBCDate = dto.arrivalToBCDate ? new Date(dto.arrivalToBCDate) : undefined;
 
     output.movedFromProvinceOrCountry = dto.movedFromProvinceOrCountry;
     output.hasBeenReleasedFromArmedForces = dto.hasBeenReleasedFromArmedForces;
     output.institutionWorkHistory = dto.institutionWorkHistory;
-    output.dischargeDate = new Date(dto.dischargeDate);
+    output.dischargeDate = dto.dischargeDate ? new Date(dto.dischargeDate) : undefined;
 
     output.fullTimeStudent = dto.fullTimeStudent;
     output.inBCafterStudies = dto.inBCafterStudies;
 
     output.schoolName = dto.schoolName;
-    output.studiesDepartureDate = new Date(dto.studiesDepartureDate);
-    output.studiesFinishedDate = new Date(dto.studiesFinishedDate);
-    output.studiesBeginDate = new Date(dto.studiesBeginDate);
+    output.studiesDepartureDate = dto.studiesDepartureDate ? new Date(dto.studiesDepartureDate) : undefined;
+    output.studiesBeginDate = dto.studiesBeginDate ? new Date(dto.studiesBeginDate) : undefined;
+    output.studiesFinishedDate = dto.studiesFinishedDate ? new Date(dto.studiesFinishedDate) : undefined;
 
     output.schoolOutsideOfBC = dto.schoolOutsideOfBC;
 
@@ -314,7 +311,7 @@ export class MspAccountMaintenanceDataService {
       dto.declarationForOutsideOver60Days;
 
     output.newlyAdopted = dto.newlyAdopted;
-    output.adoptedDate = new Date(dto.adoptedDate);
+    output.adoptedDate = dto.adoptedDate ? new Date(dto.adoptedDate) : undefined;
 
     output.reasonForCancellation = dto.reasonForCancellation;
     output.prevLastName = dto.prevLastName;
@@ -329,14 +326,14 @@ export class MspAccountMaintenanceDataService {
     output.departureReason = dto.departureReason;
     output.departureReason12Months = dto.departureReason12Months;
     output.departureDestination12Months = dto.departureDestination12Months;
-    output.departureDateDuring12MonthsDate = new Date(dto.departureDateDuring12MonthsDate);
-    output.departureDateDuring6MonthsDate = new Date(dto.departureDateDuring6MonthsDate);
-    output.returnDateDuring12MonthsDate = new Date(dto.returnDateDuring12MonthsDate);
-    output.returnDateDuring6MonthsDate = dto.returnDateDuring6MonthsDate;
+    output.departureDateDuring12MonthsDate = dto.departureDateDuring12MonthsDate ? new Date(dto.departureDateDuring12MonthsDate): undefined;
+    output.departureDateDuring6MonthsDate = dto.departureDateDuring6MonthsDate ? new Date(dto.departureDateDuring6MonthsDate) : undefined;
+    output.returnDateDuring12MonthsDate = dto.returnDateDuring12MonthsDate ? new Date(dto.returnDateDuring12MonthsDate) : undefined;
+    output.returnDateDuring6MonthsDate = dto.returnDateDuring6MonthsDate ? new Date(dto.returnDateDuring6MonthsDate) : undefined;
     output.nameOfInstitute = dto.nameOfInstitute;
 
 
-    output.cancellationDate = new Date(dto.cancellationDate);
+    output.cancellationDate = dto.cancellationDate ? new Date(dto.cancellationDate) : undefined;
     if (dto.gender) {
       output.gender = dto.gender;
     }
@@ -386,7 +383,6 @@ export class MspAccountMaintenanceDataService {
   }
 
   toMspAccountAppTransferObject(input: MspAccountApp): MspAccountDto {
-    console.log('toMspAccountAppTransferObject ran');
     const dto: MspAccountDto = new MspAccountDto();
     dto.addressUpdate = input.accountChangeOptions.addressUpdate;
 
@@ -457,7 +453,6 @@ export class MspAccountMaintenanceDataService {
 
 
   private toOutofBCRecordDto(outofBCRecord: OutofBCRecord) {
-    console.log('toOutofBCRecordDto ran');
     if (outofBCRecord == null) return null;
 
     const dto: OutofBCRecordDto = new OutofBCRecordDto();
@@ -469,19 +464,17 @@ export class MspAccountMaintenanceDataService {
   }
 
   private toOutofBCRecord(dto: OutofBCRecordDto) {
-    console.log('toOutofBCRecord ran');
     if (dto == null) return null;
 
     const rec: OutofBCRecord = new OutofBCRecord();
     rec.reason = dto.reason;
     rec.location = dto.location;
-    rec.departureDate = new Date(dto.departureDate);
-    rec.returnDate = new Date(dto.returnDate);
+    rec.departureDate = dto.departureDate ? new Date(dto.departureDate) : undefined;
+    rec.returnDate = dto.returnDate ? new Date(dto.returnDate) : undefined;
     return rec;
   }
 
   private fromMspAccountTransferObject(dto: MspAccountDto): MspAccountApp {
-    console.log('fromMspAccountTransferObject ran');
     const output: MspAccountApp = new MspAccountApp();
 
     output.accountChangeOptions.addressUpdate = dto.addressUpdate;
@@ -495,7 +488,7 @@ export class MspAccountMaintenanceDataService {
       dto.nameChangeDueToMarriage;
 
     output.authorizedByApplicant = dto.authorizedByApplicant;
-    output.authorizedByApplicantDate = dto.authorizedByApplicantDate;
+    output.authorizedByApplicantDate = dto.authorizedByApplicantDate ? new Date(dto.authorizedByApplicantDate) : undefined;
     output.authorizedBySpouse = dto.authorizedBySpouse;
 
     output.infoCollectionAgreement = dto.infoCollectionAgreement;


### PR DESCRIPTION
Making a draft PR for you guys to look at and play with.
This fixes the date related refresh issues, and refreshing on any 
page doesn't throw errors anymore, but submitting after a 
refresh fails, due to UUID issues. This is likely related to the 
following: after refresh, the only thing that doesn't repopulate 
correctly is attachments. Regardless, `convertToAttachment` is 
where the issue begins and it occurs even in submissions with 
no attachments.

I am still looking into this but I just thought I'd put this up if 
anyone was curious.