### PR TITLE
DEAM-395: PHN not required for sp / ch

### DIFF
--- a/MSPApplicationSchema.json
+++ b/MSPApplicationSchema.json
@@ -610,8 +610,7 @@
       },
       "required": [
         "name",
-        "birthDate",
-        "phn"
+        "birthDate"
       ]
     },
     "AccountChangeSpousesType":{
@@ -701,8 +700,7 @@
       "required": [
         "name",
         "birthDate",
-        "operationAction",
-        "phn"
+        "operationAction"
       ]
     },
     "AccountChangeChildrenType": {

--- a/src/app/models/schema.ts
+++ b/src/app/models/schema.ts
@@ -610,8 +610,7 @@ export const defaultSchema = {
       },
       required: [
         'name',
-        'birthDate',
-        'phn'
+        'birthDate'
       ]
     },
     AccountChangeSpousesType: {
@@ -701,8 +700,7 @@ export const defaultSchema = {
       required: [
         'name',
         'birthDate',
-        'operationAction',
-        'phn'
+        'operationAction'
       ]
     },
     AccountChangeChildrenType: {

--- a/src/app/modules/account/components/personal-information/personal-information.component.ts
+++ b/src/app/modules/account/components/personal-information/personal-information.component.ts
@@ -11,6 +11,8 @@ export interface IPersonalInformation {
   lastName: string;
   dateOfBirth: Date;
   relationship: Relationship;
+  hasActiveMedicalServicePlan: boolean;
+  immigrationStatusChange: boolean;
 
   // Read only values (properties) must be set if you want the field to display with no values.
   readonly genderRequired?: boolean;
@@ -108,7 +110,8 @@ export class AccountPersonalInformationComponent<T extends IPersonalInformation>
   }
 
   get requiresPhn() {
-    return this.person.phnRequired;
+    // If added spouse or child checked "no" to "...have active Medical Services Plan Coverage?" then PHN not required
+    return this.person.hasActiveMedicalServicePlan !== false && this.person.immigrationStatusChange !== false;
   }
 
   get phn() {

--- a/src/app/modules/account/pages/confirmation/confirmation.component.html
+++ b/src/app/modules/account/pages/confirmation/confirmation.component.html
@@ -24,7 +24,7 @@
 
       <!-- If the user added a spouse or child with NO PREVIOUS MSP, means he/she is a completely new resident
       to BC and needs to go to ICBC to get their picture taken, in this only case is when the 3rd blue box needs to be displayed.-->
-      <div *ngIf="hasAddedSpouseOrChildWithNoPrevMSP" AdditionalInfo>
+      <div *ngIf="isSuccess && hasAddedSpouseOrChildWithNoPrevMSP" AdditionalInfo>
         <br>
         <h2 class="horizontal-line"><strong>Next Steps</strong></h2>
         <common-page-section layout='noTips'>


### PR DESCRIPTION
This is not yet ready to be merged, but please review when 
convenient

---
If AH adds a spouse or child and they don't have existing MSP
coverage, they should not be asked for a PHN. The front end
changes have been made in this PR (see attached below) as well
as changes to FE schema, but the middleware schema needs to 
be changed as well or submissions will fail. Middleware changes
are in-progress (Jing is working on it)

Once those changes have been made and I've tested 
submissions, I will convert this to a PR from a draft.

As an aside, the error page's "Next Steps" section looks like it
could use more content and not only (or maybe at all) refer to 
Enrolment (see attached below)

>### PHN not required if they don't have existing MSP:
![spouse_without_MSP](https://user-images.githubusercontent.com/32586431/88855290-7ae82800-d1a7-11ea-9257-a036d03f9e96.PNG)
![child_without_MSP](https://user-images.githubusercontent.com/32586431/88855284-7a4f9180-d1a7-11ea-8314-76e600ecedab.PNG)
---
>### Still required if they do have existing MSP:
![child_with_MSP](https://user-images.githubusercontent.com/32586431/88855283-79b6fb00-d1a7-11ea-8323-37d637426108.PNG)
![spouse_with_MSP](https://user-images.githubusercontent.com/32586431/88855288-7ae82800-d1a7-11ea-82db-359d863af2e8.PNG)
---
>### Update and remove unaffected:
![remove_spouse](https://user-images.githubusercontent.com/32586431/88855287-7ae82800-d1a7-11ea-8e6e-fc6dbf75b35e.PNG)
![update_spouse](https://user-images.githubusercontent.com/32586431/88855292-7b80be80-d1a7-11ea-9a22-4d0a36d59f3a.PNG)
---
>### Odd Next Steps section:
![unrequired_phn_failed_submission](https://user-images.githubusercontent.com/32586431/88855184-51c79780-d1a7-11ea-816d-95331e493463.PNG)
