### PR TITLE
DEAM-395: Still show non-mandatory PHN

### DIFF
--- a/src/app/modules/account/components/personal-information/personal-information.component.html
+++ b/src/app/modules/account/components/personal-information/personal-information.component.html
@@ -39,12 +39,13 @@
   </div>
 
   <!--Display phn if defined in person object-->
-  <div *ngIf="requiresPhn" class="form-group col-sm-6 pl-0">
+  <div class="form-group col-sm-6 pl-0">
     <common-phn
       name="phn_{{objectId}}"
       [(ngModel)]="phn"
       [errorMessage]="phnErrorMsg"
-      required
+      [required]="requiresPhn"
+      [label]="phnLabel"
       commonDuplicateCheck
       [dupList]="phnList">
     </common-phn>

--- a/src/app/modules/account/components/personal-information/personal-information.component.ts
+++ b/src/app/modules/account/components/personal-information/personal-information.component.ts
@@ -123,6 +123,14 @@ export class AccountPersonalInformationComponent<T extends IPersonalInformation>
     this.personChange.emit(this.person);
   }
 
+  get phnLabel() {
+    if (this.requiresPhn) {
+      return 'Personal Health Number (PHN)';
+    } else {
+      return 'Personal Health Number (PHN) (optional)';
+    }
+  }
+
   get dateOfBirth() {
     return this.person.dateOfBirth;
   }


### PR DESCRIPTION
As requested by Ernesto, the PHN field now still shows even when sp/ch
don't have existing MSP. It is now (in that case) optional, and the
new label indicates this. The previous change hid the field entirely.
AH info, spouse/child update and remove all unaffected. 
Submissions both with and without the optional PHN work

New Screenshots:
![phn_optional](https://user-images.githubusercontent.com/32586431/88932307-bf6cd580-d232-11ea-945d-886e97c244b1.PNG)
![phn_mandatory](https://user-images.githubusercontent.com/32586431/88932301-bda31200-d232-11ea-877a-6cdae310b7a9.PNG)
