### PR TITLE
DEAM-396: Remove residency info if child has MSP

### DIFF
--- a/src/app/modules/account/components/moving-information/moving-information.component.html
+++ b/src/app/modules/account/components/moving-information/moving-information.component.html
@@ -1,5 +1,6 @@
 <ng-content select="[sectionTitleInfo]"></ng-content>
-<common-page-section layout="tips">
+<!-- Only show the residency info if they are not on MSP already -->
+<common-page-section *ngIf="person.hasActiveMedicalServicePlan === false || person.immigrationStatusChange === false" layout="tips">
   <div *ngIf="isStatus == undefined || isCanadianNotBC || isResidentNotBC" class="form-group">
     <common-radio
       name="livedInBCSinceBirth_{{objectId}}"
@@ -282,8 +283,8 @@
   </div>
 </common-page-section>
 
-<common-page-section layout="tips">
-  <div *ngIf="person.relationship === Child19To24">
+<common-page-section *ngIf="person.relationship === Child19To24" layout="tips">
+  <div>
     <h2><strong>School Information</strong></h2>
     <p class="horizontal-line">
       Enter information of the school that this child is attending (must be in full-time attendance)

--- a/src/app/modules/account/pages/child-info/add-child/add-child.component.html
+++ b/src/app/modules/account/pages/child-info/add-child/add-child.component.html
@@ -70,7 +70,7 @@
     [person]="child"
     [phnList]="phnList">
     <div sectionTitleInfo>
-      <h2>Child's Personal Information</h2>
+      <h2><strong>Child's Personal Information</strong></h2>
       <p class="horizontal-line">
         Enter the child's legal name as it appears on their official Canadian identity
         documents, e.g., birth certificate, permanent resident card, passport.
@@ -94,7 +94,8 @@
   <!-- Child's Residency Information -->
   <msp-child-moving-information
     [person]="child">
-    <div sectionTitleInfo>
+    <!-- Don't show the residency header if they have MSP already -->
+    <div *ngIf="hasActiveMedicalCoverage === false" sectionTitleInfo>
       <h2><strong>Child's Residency Information</strong></h2>
       <p class="horizontal-line"></p>
     </div>

--- a/src/app/modules/account/pages/child-info/child-info.component.ts
+++ b/src/app/modules/account/pages/child-info/child-info.component.ts
@@ -261,18 +261,6 @@ export class ChildInfoComponent extends BaseForm implements OnInit, AfterViewIni
         && this.isSet(addedChild.hasActiveMedicalServicePlan)
         // Ticked "Gender"
         && this.isSet(addedChild.gender)
-        // Ticked "Is this child newly adopted?"
-        && this.isSet(addedChild.newlyAdopted)
-        // Ticked "Is this a permanent move to BC for this child?"
-        && this.isSet(addedChild.madePermanentMoveToBC)
-        // Disable continue if they are going to live in BC permanently
-        && addedChild.madePermanentMoveToBC !== false
-        // Ticked "more than 30 days in the last 12 months"
-        && this.isSet(addedChild.declarationForOutsideOver30Days)
-        // Ticked "more than 30 days in the next 6 months"
-        && this.isSet(addedChild.declarationForOutsideOver60Days)
-        // Ticked "Has this child been released from the Canadian Armed Forces?"
-        && this.isSet(addedChild.hasBeenReleasedFromArmedForces)
 
       // Ticked "19 - 24" under "How old is the child?"
       if (addedChild.relationship === Relationship.Child19To24) {
@@ -302,50 +290,65 @@ export class ChildInfoComponent extends BaseForm implements OnInit, AfterViewIni
         valid = valid && this.isSet(addedChild.status)
           && this.isSet(addedChild.updateStatusInCanadaDocType.images)
           && addedChild.updateStatusInCanadaDocType.images.length > 0
-          && this.isSet(addedChild.hasNameChange);
-
-          if (addedChild.hasNameChange === true) {
+          // Ticked "Has this child's name changed?"
+          && this.isSet(addedChild.hasNameChange)
+          // Ticked "Is this child newly adopted?"
+          && this.isSet(addedChild.newlyAdopted)
+          // Ticked "Is this a permanent move to BC for this child?"
+          && this.isSet(addedChild.madePermanentMoveToBC)
+          // Disable continue if they are going to live in BC permanently
+          && addedChild.madePermanentMoveToBC !== false
+          // Ticked "more than 30 days in the last 12 months"
+          && this.isSet(addedChild.declarationForOutsideOver30Days)
+          // Ticked "more than 30 days in the next 6 months"
+          && this.isSet(addedChild.declarationForOutsideOver60Days)
+          // Ticked "Has this child been released from the Canadian Armed Forces?"
+          && this.isSet(addedChild.hasBeenReleasedFromArmedForces)
+          
+        // Yes to name change
+        if (addedChild.hasNameChange === true) {
+          // Check they uploaded at least 1 doc
           valid = valid && addedChild.nameChangeDocs
           && this.isSet(addedChild.nameChangeDocs.images)
           && addedChild.nameChangeDocs.images.length > 0;
         }
-      }
 
-      // No to "lived in BC since birth"
-      if (addedChild.livedInBCSinceBirth === false) {
-        // Check they inputted the province or country they came from and the date
-        valid = valid && this.isSet(addedChild.arrivalToBCDate)
-          && this.isSet(addedChild.movedFromProvinceOrCountry)
-          && typeof addedChild.movedFromProvinceOrCountry === 'string'
-          && addedChild.movedFromProvinceOrCountry.length > 0;
-      }
+        // No to "lived in BC since birth"
+        if (addedChild.livedInBCSinceBirth === false) {
+          // Check they inputted the province or country they came from and the date
+          valid = valid && this.isSet(addedChild.arrivalToBCDate)
+            && this.isSet(addedChild.movedFromProvinceOrCountry)
+            && typeof addedChild.movedFromProvinceOrCountry === 'string'
+            && addedChild.movedFromProvinceOrCountry.length > 0;
+        }
 
-      // Yes to "newly adopted"
-      if (addedChild.newlyAdopted === true) {
-        // Check they inputted the province or country they came from and the date
-        valid = valid && this.isSet(addedChild.adoptedDate)
-      }
+        // Yes to "newly adopted"
+        if (addedChild.newlyAdopted === true) {
+          // Check they inputted the province or country they came from and the date
+          valid = valid && this.isSet(addedChild.adoptedDate)
+        }
 
-      // Yes to "more than 30 days in the last 12 months"
-      if (addedChild.declarationForOutsideOver30Days === true) {
-        valid = valid && this.isSet(addedChild.departureDateDuring12MonthsDate)
-          && this.isSet(addedChild.returnDateDuring12MonthsDate)
-          && this.isSet(addedChild.departureReason12Months)
-          && this.isSet(addedChild.departureDestination12Months)
-      }
+        // Yes to "more than 30 days in the last 12 months"
+        if (addedChild.declarationForOutsideOver30Days === true) {
+          valid = valid && this.isSet(addedChild.departureDateDuring12MonthsDate)
+            && this.isSet(addedChild.returnDateDuring12MonthsDate)
+            && this.isSet(addedChild.departureReason12Months)
+            && this.isSet(addedChild.departureDestination12Months)
+        }
 
-      // Yes to "more than 30 days in the next 6 months"
-      if (addedChild.declarationForOutsideOver60Days === true) {
-        valid = valid && this.isSet(addedChild.departureDateDuring6MonthsDate)
-          && this.isSet(addedChild.returnDateDuring6MonthsDate)
-          && this.isSet(addedChild.departureReason)
-          && this.isSet(addedChild.departureDestination)
-      }
+        // Yes to "more than 30 days in the next 6 months"
+        if (addedChild.declarationForOutsideOver60Days === true) {
+          valid = valid && this.isSet(addedChild.departureDateDuring6MonthsDate)
+            && this.isSet(addedChild.returnDateDuring6MonthsDate)
+            && this.isSet(addedChild.departureReason)
+            && this.isSet(addedChild.departureDestination)
+        }
 
-      // Yes to "released from Canadian Armed Forces"
-      if (addedChild.hasBeenReleasedFromArmedForces === true) {
-        valid = valid && this.isSet(addedChild.dischargeDate)
-          && this.isSet(addedChild.nameOfInstitute)
+        // Yes to "released from Canadian Armed Forces"
+        if (addedChild.hasBeenReleasedFromArmedForces === true) {
+          valid = valid && this.isSet(addedChild.dischargeDate)
+            && this.isSet(addedChild.nameOfInstitute)
+        }
       }
     })
 

--- a/src/app/modules/account/pages/spouse-info/add-spouse/add-spouse.component.html
+++ b/src/app/modules/account/pages/spouse-info/add-spouse/add-spouse.component.html
@@ -83,7 +83,7 @@
     [person]="spouse"
     [phnList]="phnList">
     <div sectionTitleInfo>
-      <h2>Spouse's Personal Information</h2>
+      <h2><strong>Spouse's Personal Information</strong></h2>
       <p class="horizontal-line">
         Enter your spouse's legal name as it appears on their official Canadian identity documents,
         e.g., birth certificate, permanent resident card, passport.


### PR DESCRIPTION
What I did:
1) Move add-child validation for residency info into if so it's only
checked if they don't have MSP
2) Bolden headers
3) Conditionally render residency info section

As an aside the child-moving-information cmpt should be broken up and
I think the spouse should use the hasActiveMedicalServicePlan like the
child does instead of immigrationStatusChange. I am not changing these 
right now due to the time pressure, but for maintainence it's worth noting