### PR TITLE
DEAM-398: Remove Work Permit from child options

### DIFF
--- a/src/app/modules/msp-core/components/canadian-status/canadian-status.component.ts
+++ b/src/app/modules/msp-core/components/canadian-status/canadian-status.component.ts
@@ -30,8 +30,8 @@ export function statusReasonRules(relationship: Relationship,
     case StatusInCanada.CitizenAdult:
     case StatusInCanada.PermanentResident:
       if (relationship === Relationship.Child19To24 ||
-          relationship === Relationship.ChildUnder19 ||
-          relationship === Relationship.ChildUnder24) {
+        relationship === Relationship.ChildUnder19 ||
+        relationship === Relationship.ChildUnder24) {
         return [
           CanadianStatusReason.MovingFromProvince,
           CanadianStatusReason.MovingFromCountry,
@@ -52,6 +52,15 @@ export function statusReasonRules(relationship: Relationship,
           CanadianStatusReason.StudyingInBC,
           CanadianStatusReason.ReligiousWorker,
           CanadianStatusReason.Diplomat];
+        // If it's a child, don't show "Work Permit" as an option
+      } else if (relationship === Relationship.Child19To24
+        || relationship === Relationship.ChildUnder19
+        || relationship === Relationship.Child) { 
+        return [
+          CanadianStatusReason.StudyingInBC,
+          CanadianStatusReason.ReligiousWorker,
+          CanadianStatusReason.Diplomat,
+          CanadianStatusReason.Visiting];
       } else {
         return [
           CanadianStatusReason.WorkingInBC,


### PR DESCRIPTION
Please review when convenient. Will not merge until we get the go ahead, they
might want us to leave this one for maintenance. I've set it to apply to all children
but it's easy to change it to only affect a specific child age group if they decide
they want that

AH and Spouse dropdowns are unaffected, see attached

>### Old:
![update_work_permit](https://user-images.githubusercontent.com/32586431/88977512-e814bf80-d272-11ea-8c69-6424f27c56ae.PNG)
![work_permit](https://user-images.githubusercontent.com/32586431/88977513-e814bf80-d272-11ea-8a58-23694568979a.PNG)

>### New:
![work_permit_gone](https://user-images.githubusercontent.com/32586431/88977514-e814bf80-d272-11ea-9d03-4519f33dd201.PNG)
![update_no_work_permit](https://user-images.githubusercontent.com/32586431/88977511-e77c2900-d272-11ea-9985-eb2a883c67be.PNG)

