### PR TITLE
DEAM-400: Update unit tests in request-acl

### DIFF
--- a/src/app/modules/request-acl/pages/acl-confirmation/acl-confirmation.component.spec.ts
+++ b/src/app/modules/request-acl/pages/acl-confirmation/acl-confirmation.component.spec.ts
@@ -1,18 +1,24 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ActivatedRoute } from '@angular/router';
 import { AclConfirmationComponent } from './acl-confirmation.component';
+import { ApiStatusCodes } from 'moh-common-lib';
 
 describe('AclConfirmationComponent', () => {
   let component: AclConfirmationComponent;
   let fixture: ComponentFixture<AclConfirmationComponent>;
 
   beforeEach(async(() => {
+    const activatedRouteStub = () => ({
+      queryParams: { subscribe: f => f({}) }
+    });
     TestBed.configureTestingModule({
-      declarations: [ AclConfirmationComponent ]
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [ AclConfirmationComponent ],
+      providers: [{ provide: ActivatedRoute, useFactory: activatedRouteStub }]
     })
     .compileComponents();
   }));
-
   beforeEach(() => {
     fixture = TestBed.createComponent(AclConfirmationComponent);
     component = fixture.componentInstance;
@@ -21,5 +27,9 @@ describe('AclConfirmationComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+  
+  it('should have default status value', () => {
+    expect(component.status).toEqual(ApiStatusCodes.ERROR);
   });
 });

--- a/src/app/modules/request-acl/pages/request-letter/request-letter.component.spec.ts
+++ b/src/app/modules/request-acl/pages/request-letter/request-letter.component.spec.ts
@@ -1,14 +1,45 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ChangeDetectorRef } from '@angular/core';
+import { Router } from '@angular/router';
+import { HeaderService } from '../../../../services/header.service';
+import { AclDataService } from '../../services/acl-data.service';
+import { MspLogService } from '../../../../services/log.service';
+import { AclApiService } from '../../services/acl-api.service';
+import { FormsModule } from '@angular/forms';
 import { RequestLetterComponent } from './request-letter.component';
+import { environment } from '../../../../../environments/environment';
 
 describe('RequestLetterComponent', () => {
   let component: RequestLetterComponent;
   let fixture: ComponentFixture<RequestLetterComponent>;
 
   beforeEach(async(() => {
+    const changeDetectorRefStub = () => ({ detectChanges: () => ({}) });
+    const routerStub = () => ({ url: {} });
+    const headerServiceStub = () => ({ setTitle: string => ({}) });
+    const aclDataServiceStub = () => ({
+      application: { infoCollectionAgreement: {} },
+      saveApplication: () => ({}),
+      removeApplication: () => ({})
+    });
+    const mspLogServiceStub = () => ({ log: (object, string) => ({}) });
+    const aclApiServiceStub = () => ({
+      sendAclRequest: application => ({ subscribe: f => f({}) }),
+      sendSpaEnvServer: arg => ({ subscribe: f => f({}) })
+    });
     TestBed.configureTestingModule({
-      declarations: [ RequestLetterComponent ]
+      imports: [FormsModule],
+      schemas: [NO_ERRORS_SCHEMA],
+      declarations: [RequestLetterComponent],
+      providers: [
+        { provide: ChangeDetectorRef, useFactory: changeDetectorRefStub },
+        { provide: Router, useFactory: routerStub },
+        { provide: HeaderService, useFactory: headerServiceStub },
+        { provide: AclDataService, useFactory: aclDataServiceStub },
+        { provide: MspLogService, useFactory: mspLogServiceStub },
+        { provide: AclApiService, useFactory: aclApiServiceStub }
+      ]
     })
     .compileComponents();
   }));
@@ -21,5 +52,30 @@ describe('RequestLetterComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it(`should have the default loading value`, () => {
+    expect(component.loading).toEqual(false);
+  });
+
+  it(`should have the default captchaApiBaseUrl value`, () => {
+    expect(component.captchaApiBaseUrl).toEqual(
+      environment.appConstants.captchaApiBaseUrl
+    );
+  });
+
+  it(`should have the default showCaptcha value`, () => {
+    expect(component.showCaptcha).toEqual(false);
+  });
+
+  describe('ngOnInit', () => {
+    it('makes expected call', () => {
+      const mspLogServiceStub: MspLogService = fixture.debugElement.injector.get(
+        MspLogService
+      );
+      spyOn(mspLogServiceStub, 'log').and.callThrough();
+      component.ngOnInit();
+      expect(mspLogServiceStub.log).toHaveBeenCalled();
+    });
   });
 });

--- a/src/app/modules/request-acl/services/acl-api.service.spec.ts
+++ b/src/app/modules/request-acl/services/acl-api.service.spec.ts
@@ -1,12 +1,23 @@
 import { TestBed } from '@angular/core/testing';
-
+import {
+  HttpClientTestingModule,
+  HttpTestingController
+} from '@angular/common/http/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { AclApplication } from '../model/acl-application.model';
 import { AclApiService } from './acl-api.service';
 
 describe('AclApiService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  let service: AclApiService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+      providers: [AclApiService]
+    });
+    service = TestBed.get(AclApiService);
+  });
 
-  it('should be created', () => {
-    const service: AclApiService = TestBed.get(AclApiService);
+  it('should create', () => {
     expect(service).toBeTruthy();
   });
 });

--- a/src/app/modules/request-acl/services/acl-data.service.spec.ts
+++ b/src/app/modules/request-acl/services/acl-data.service.spec.ts
@@ -1,12 +1,37 @@
 import { TestBed } from '@angular/core/testing';
-
+import { LocalStorageService } from 'angular-2-local-storage';
 import { AclDataService } from './acl-data.service';
 
 describe('AclDataService', () => {
-  beforeEach(() => TestBed.configureTestingModule({}));
+  let service: AclDataService;
+  beforeEach(() => {
+    const localStorageServiceStub = () => ({
+      set: (_storageKey, dto) => ({}),
+      get: _storageKey => ({})
+    });
 
-  it('should be created', () => {
-    const service: AclDataService = TestBed.get(AclDataService);
+    TestBed.configureTestingModule({
+      providers: [
+        AclDataService,
+        { provide: LocalStorageService, useFactory: localStorageServiceStub }
+      ]
+    });
+
+    service = TestBed.get(AclDataService);
+  });
+
+  it('should create', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('saveApplication', () => {
+    it('makes expected call', () => {
+      const localStorageServiceStub: LocalStorageService = TestBed.get(
+        LocalStorageService
+      );
+      spyOn(localStorageServiceStub, 'set').and.callThrough();
+      service.saveApplication();
+      expect(localStorageServiceStub.set).toHaveBeenCalled();
+    });
   });
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -26,7 +26,7 @@ getTestBed().initTestEnvironment(
 );
 // Then we find all the tests.
 const context = require.context('./', true, /\.spec\.ts$/);
-// const context = require.context('./app/modules/msp-core/components/personal-information', true, /\.spec\.ts$/);
+// const context = require.context('./app/modules/request-acl', true, /\.spec\.ts$/);
 // And load the modules.
 context.keys().map(context);
 // Finally, start Karma to run the tests.


### PR DESCRIPTION
Please review when convenient. To run these tests, swap the comment on the
`const context` lines in ./src/test.ts and run `ng test`

There was 4 tests failing out of 5, there should now be 11 passing (double with
karma browser)