### PR TITLE
DEAM-414: Prevent certain resubmissions

### DIFF
--- a/src/app/modules/account/pages/sending/sending.component.ts
+++ b/src/app/modules/account/pages/sending/sending.component.ts
@@ -1,4 +1,4 @@
-import {Component, Inject, Injectable, AfterContentInit, ViewChild, ElementRef} from '@angular/core';
+import {Component, Inject, Injectable, AfterContentInit, ViewChild, ElementRef, OnInit} from '@angular/core';
 import {  MspAccountMaintenanceDataService } from '../../services/msp-account-data.service';
 import { MspApiAccountService } from '../../services/msp-api-account.service';
 import {Router} from '@angular/router';
@@ -17,7 +17,7 @@ import { BaseForm } from '../../models/base-form';
   styleUrls: ['./sending.component.scss']
 })
 @Injectable()
-export class AccountSendingComponent extends BaseForm implements AfterContentInit {
+export class AccountSendingComponent extends BaseForm implements AfterContentInit, OnInit {
   lang = require('./i18n');
   static ProcessStepNum = 6;
   mspAccountApp: MspAccountApp;
@@ -41,6 +41,18 @@ export class AccountSendingComponent extends BaseForm implements AfterContentIni
     this.transmissionInProcess = undefined;
     this.hasError = undefined;
     this.showMoreErrorDetails = undefined;
+  }
+
+  ngOnInit() {
+    /* 
+    If they do not have a valid auth token
+    eg. they have already successfully submitted 
+    and just hit the back button 
+    */
+    if (!this.mspAccountApp.hasValidAuthToken) {
+      // Send them back to the home screen and reload the app
+      location.assign('/');
+    }
   }
 
   /**


### PR DESCRIPTION
Done to prevent re-submissions when they navigate back to /sending after
a successful submission. The previous behavior was if you successfully 
submit and then press back and go to /sending, it would attempt and
fail to submit, as the application data would now be empty. The new 
behavior is it redirects to the landing and reloads if you press back 
after a successful submission

Please check out this branch and review when convenient. I also advise
trying it with the environment set to `bypassGuards = false` to ensure
the same behavior will work when deployed