### PR TITLE
DEAM-419: Add interceptor to extend timeout

### DIFF
--- a/src/app/interceptors/timeout.interceptor.spec.ts
+++ b/src/app/interceptors/timeout.interceptor.spec.ts
@@ -1,0 +1,26 @@
+import { TestBed } from '@angular/core/testing';
+import { HttpHandler } from '@angular/common/http';
+import { HttpRequest } from '@angular/common/http';
+import { TimeoutInterceptor, DEFAULT_TIMEOUT } from './timeout.interceptor';
+
+fdescribe('TimeoutInterceptor', () => {
+  let service: TimeoutInterceptor;
+  beforeEach(() => {
+    TestBed.configureTestingModule({ providers: [TimeoutInterceptor, [{ provide: DEFAULT_TIMEOUT, useValue: 60000 }]] });
+    service = TestBed.get(TimeoutInterceptor);
+  });
+
+  it('should create', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('intercept', () => {
+    it('makes expected calls', () => {
+      const httpHandlerStub: HttpHandler = <any>{ handle: () => ({ pipe: () => {} }) };
+      const httpRequestStub: HttpRequest<any> = <any>{ headers: { get: () => {} } };
+      spyOn(httpHandlerStub, 'handle').and.callThrough();
+      service.intercept(httpRequestStub, httpHandlerStub);
+      expect(httpHandlerStub.handle).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/app/interceptors/timeout.interceptor.ts
+++ b/src/app/interceptors/timeout.interceptor.ts
@@ -1,0 +1,18 @@
+import { Inject, Injectable, InjectionToken } from '@angular/core';
+import { HttpEvent, HttpHandler, HttpInterceptor, HttpRequest } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { timeout } from 'rxjs/operators';
+
+export const DEFAULT_TIMEOUT = new InjectionToken<number>('defaultTimeout');
+
+@Injectable()
+export class TimeoutInterceptor implements HttpInterceptor {
+  constructor(@Inject(DEFAULT_TIMEOUT) protected defaultTimeout: number) {
+  }
+
+  intercept(req: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
+    const timeoutValue = req.headers.get('timeout') || this.defaultTimeout;
+    const timeoutValueNumeric = Number(timeoutValue);
+    return next.handle(req).pipe(timeout(timeoutValueNumeric));
+  }
+}

--- a/src/app/modules/account/account.module.ts
+++ b/src/app/modules/account/account.module.ts
@@ -38,6 +38,8 @@ import { environment } from 'environments/environment';
 import { AccountPersonCardComponent } from './components/person-card/person-card.component';
 import { AccountPersonalInformationComponent } from './components/personal-information/personal-information.component';
 import { ProcessService , ProcessStep} from '../../services/process.service';
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { TimeoutInterceptor, DEFAULT_TIMEOUT } from 'app/interceptors/timeout.interceptor';
 @NgModule({
   imports: [
     CommonModule,
@@ -83,7 +85,11 @@ import { ProcessService , ProcessStep} from '../../services/process.service';
     { provide: AbstractPageGuardService, useExisting: DefaultPageGuardService },
     LoadPageGuardService,
     MspAccountMaintenanceDataService,
-    MspApiAccountService
+    MspApiAccountService,
+    // Used to adjust the default timeout limit
+    { provide: HTTP_INTERCEPTORS, useClass: TimeoutInterceptor, multi: true },
+    { provide: DEFAULT_TIMEOUT, useValue: 60000 }
+  
   ]
 })
 


### PR DESCRIPTION
To test that the interceptor works, lower it to one second and verify
that all requests over one second time out. So when we if we extend the
timeout to 60 seconds we know the remaining 30 second timeout is coming
from something than the angular app (openshift, browser, etc)

*This commit only affects the timeout for the account module, if it
works after some config change we can just put it in the providers 
for all other modules that use the captcha*