### PR TITLE
DEAM-420: Disable uploads with too high a size

### DIFF
--- a/src/app/modules/msp-core/components/support-documents/support-documents.component.html
+++ b/src/app/modules/msp-core/components/support-documents/support-documents.component.html
@@ -51,10 +51,11 @@
       id="docUploader_{{objectId}}"
       [required]="true"
       instructionText="{{uploadInstructions}}"
-      (errorDocument)="handleSupportDocError($event)">
+      (errorDocument)="handleSupportDocError($event)"
+      (imagesChange)="handleImagesChange($event)">
     </common-file-uploader>
     <common-error-container
-      [displayError]="supportDocError !== null">
+      [displayError]="supportDocErrorMsg">
       {{ supportDocErrorMsg }}
     </common-error-container>
     <ng-content select="[requestAdditionInfo]"></ng-content>

--- a/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
+++ b/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
@@ -226,7 +226,7 @@ export class SupportDocumentsComponent extends Base
     if (sum > 1048576) {
       // Reset the attachments for this upload
       this.documents = [];
-      this.supportDocErrorMsg = 'The upload you are attempting is too large.';
+      this.supportDocErrorMsg = 'The addition of the previous document exceeded the maximum upload size of this supporting document section.';
     } else {
       this.supportDocErrorMsg = '';
     }

--- a/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
+++ b/src/app/modules/msp-core/components/support-documents/support-documents.component.ts
@@ -212,7 +212,27 @@ export class SupportDocumentsComponent extends Base
     });
   }
 
-  // Set the error obj and appropriate msg
+  // Check the collective size, triggered whenever an image is added or removed
+  handleImagesChange(imgs: Array<CommonImage>) {
+    let sum = 0;
+
+    this.documents.forEach((img) => { 
+      if (typeof img.size === 'number') {
+        sum += img.size;
+      }
+    });
+    
+    // Same limit as moh-common-lib
+    if (sum > 1048576) {
+      // Reset the attachments for this upload
+      this.documents = [];
+      this.supportDocErrorMsg = 'The upload you are attempting is too large.';
+    } else {
+      this.supportDocErrorMsg = '';
+    }
+  }
+
+  // Set the error obj and appropriate msg, triggered when component has an error
   handleSupportDocError(error: CommonImage) {
     if (error) {
       switch (error.error) {
@@ -250,7 +270,6 @@ export class SupportDocumentsComponent extends Base
           break;
         default:
           this.supportDocError = null;
-          this.supportDocErrorMsg = '';
           break;
       }
     }
@@ -278,9 +297,7 @@ export class SupportDocumentsComponent extends Base
   }
 
   get supportDocErrorMsg() {
-    // If we have an error object and the enum is defined
-    if (this.supportDocError && this.supportDocError.error !== null && this.supportDocError.error !== undefined) {
-      // return the message
+    if (this._supportDocErrorMsg) {
       return this._supportDocErrorMsg;
     }
     return '';


### PR DESCRIPTION
To test this branch, upload a bunch of large images, over ~1.3MB after
compression, in one support document slot (enough that you'd get a
failure on current test deploy.) On this branch you should see an error
message, and the slot should be cleared. Then upload docs that are
small/few enough that it allows you to continue and removes the error,
and ensure you have the correct number of docs in the review section.
Lastly, make sure the submission is successful.

>### If user tries to upload a duplicate
![try_duplicate](https://user-images.githubusercontent.com/32586431/91899887-ac468e80-ec52-11ea-8196-a3a231d42204.PNG)
>### User can upload multiple attachments still
![multiple_small_enough](https://user-images.githubusercontent.com/32586431/91899884-abadf800-ec52-11ea-8c75-aff472399b55.PNG)
>### If user uploads more large attachments until the collective size is too high
![size_too_high_collectively](https://user-images.githubusercontent.com/32586431/91899886-ac468e80-ec52-11ea-907b-e75053b5764c.PNG)

