### PR TITLE
Modified MSP Account Data Service

### DIFF
--- a/src/app/modules/account/models/account.dto.ts
+++ b/src/app/modules/account/models/account.dto.ts
@@ -10,6 +10,8 @@ export class MspAccountDto {
   residentialAddress: AddressDto = new AddressDto();
   phoneNumber: string;
   outsideBCFor30Days: boolean;
+  liveInBC: boolean; // Currently live in BC
+  plannedAbsence: boolean; // Planned absence from BC
   unUsualCircumstance: boolean;
 
   authorizedByApplicant: boolean;

--- a/src/app/modules/account/models/account.model.ts
+++ b/src/app/modules/account/models/account.model.ts
@@ -26,6 +26,10 @@ class MspAccountApp implements ApplicationBase {
 
     pageStatus: any[] = [];
 
+    liveInBC: boolean; // Currently live in BC
+    plannedAbsence: boolean; // Planned absence from BC
+    unUsualCircumstance: boolean;
+
     authorizedByApplicant: boolean;
     authorizedByApplicantDate: Date;
     authorizedBySpouse: boolean;


### PR DESCRIPTION
Hi Bryce,

I've update MSP Account Data Service to match with the Enrol Data Service. There are methods in MSP Account Data that have different names from Enrol Data Service but uses almost the same properties so I used those existing methods instead and modify the properties under them. Let me know if there are modifications that I missed or if there are anything that I should add/remove.

Thank you,
Cyril