### PR TITLE
Update commmon lib and MSP version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mygovbc-msp",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8624,9 +8624,9 @@
       }
     },
     "moh-common-lib": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.2.2.tgz",
-      "integrity": "sha512-yLVpwSfmf0tYt9p0kGNoCk4SX0uxZQKdmvr0u5qHIT33MwptBQamwsDK7CBqZH79OIqrwbw/tyM/sCBO5KllxQ==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.2.3.tgz",
+      "integrity": "sha512-4Sp++FOXYY54neH5N2puR4lbP9vRQ8H5pAAdxYqrfiaccSc7HYCBcSEk38hSNi9MpmG3Z1yHUtVCbCJgCmuHrQ==",
       "requires": {
         "tslib": "^1.9.0",
         "zxcvbn": "^4.4.2"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8624,9 +8624,9 @@
       }
     },
     "moh-common-lib": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.2.3.tgz",
-      "integrity": "sha512-4Sp++FOXYY54neH5N2puR4lbP9vRQ8H5pAAdxYqrfiaccSc7HYCBcSEk38hSNi9MpmG3Z1yHUtVCbCJgCmuHrQ==",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/moh-common-lib/-/moh-common-lib-3.2.4.tgz",
+      "integrity": "sha512-dZR6xs2nfs9OgdpFmzs8QnL94T1vN2sbb9VtMdHkoMSNkYt6JbBk6o6JMkhKZP0X7/TMHat0BjFGOwpoiKuGHA==",
       "requires": {
         "tslib": "^1.9.0",
         "zxcvbn": "^4.4.2"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mygovbc-msp",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "MyGovBC MSP Service Provider Web App",
   "license": "Apache-2.0",
   "repository": {
@@ -90,7 +90,7 @@
     "jquery": "^3.3.1",
     "jxon": "git+https://github.com/bcgov/jxon.git",
     "lodash": "^4.17.15",
-    "moh-common-lib": "^3.2.2",
+    "moh-common-lib": "^3.2.3",
     "moment": "^2.22.2",
     "ngx-bootstrap": "^5.1.2",
     "ngx-mydatepicker": "^2.4.9",

--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "jquery": "^3.3.1",
     "jxon": "git+https://github.com/bcgov/jxon.git",
     "lodash": "^4.17.15",
-    "moh-common-lib": "^3.2.3",
+    "moh-common-lib": "^3.2.4",
     "moment": "^2.22.2",
     "ngx-bootstrap": "^5.1.2",
     "ngx-mydatepicker": "^2.4.9",

--- a/src/app/styles/overrides.scss
+++ b/src/app/styles/overrides.scss
@@ -311,11 +311,3 @@ common-date[label="Date no longer in full time studies"] {
     padding-left: 0;
   }
 }
-
-.bcgov-captcha {
-  .captcha-form {
-    .captcha-button {
-      font-family: sans-serif;
-    }
-  }
-}


### PR DESCRIPTION
New MSP Version: 3.3.0
New moh-common-lib: 3.2.4

Removed a line of font-styling for the captcha that is no longer necessary since the update