### PR TITLE
Remove aside tag on MSP DEAM Home Page

### DIFF
--- a/src/app/modules/account/pages/home/home.component.html
+++ b/src/app/modules/account/pages/home/home.component.html
@@ -37,18 +37,15 @@
         </p>
       </div>
       <div class="col-sm-12 col-md-5 home__grandchild">
-        <div class="card mb-4" style="background-color : #f2f2f2;">
-          <br>
-          <aside class="home-alert__aside-wrapper">
-            <div class="home-alert">
+        <div class="card mb-4 home-alert__container">
+          <div class="home-alert">
               <i class="fa fa-exclamation-triangle home-alert__icon" style="font-size: 35px;"></i>
               <p class="home-alert__text">
                 If you are covered on an MSP Group Plan, in which your MSP coverage
                 is managed by your employer, union, or pension plan, please contact your MSP Group Plan Administrator
                 to request account changes.
               </p>
-            </div>
-          </aside>
+          </div>
         </div>
       </div>
     </div> <br>

--- a/src/app/modules/account/pages/home/home.component.scss
+++ b/src/app/modules/account/pages/home/home.component.scss
@@ -105,10 +105,12 @@
   }
 
   // Wrapper around the alert container
-  &__aside-wrapper {
+  &__container{
       align-self: center;
       justify-self: center;
       width: 100%;
+      background-color : #f2f2f2;
+      padding: 20px 0px 0px 0px;
   }
 }
 

--- a/src/app/modules/request-acl/pages/request-letter/request-letter.component.html
+++ b/src/app/modules/request-acl/pages/request-letter/request-letter.component.html
@@ -82,7 +82,7 @@
       <common-captcha name="Captcha"
                       ngModel
                       required
-                      [apiBaseUrl]="'noway'"
+                      [apiBaseUrl]="captchaApiBaseUrl"
                       [nonce]="application.uuid"
                       (onValidToken)="application.authorizationToken=$event">
       </common-captcha>

--- a/src/app/modules/request-acl/pages/request-letter/request-letter.component.html
+++ b/src/app/modules/request-acl/pages/request-letter/request-letter.component.html
@@ -82,7 +82,7 @@
       <common-captcha name="Captcha"
                       ngModel
                       required
-                      [apiBaseUrl]="captchaApiBaseUrl"
+                      [apiBaseUrl]="'noway'"
                       [nonce]="application.uuid"
                       (onValidToken)="application.authorizationToken=$event">
       </common-captcha>

--- a/src/index.html
+++ b/src/index.html
@@ -10,7 +10,7 @@
     <title>MSP</title>
     <meta name="description" content="">
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="icon" href="favicon.ico" type="image/x-icon">
     
   </head>


### PR DESCRIPTION
Hi,

I would like to ask for your quick code review. I've removed aside and changed it to div in order to the follow the header-main content-footer landmarks.

Here's the screenshot of the changes (Same style, just used div instead of aside):
![image](https://user-images.githubusercontent.com/47836606/95524614-b1e87000-0986-11eb-89d2-2a2088dab645.png)

Regards,
Cyril
