### PR TITLE
Remove aside tag on Home Page

### DIFF
--- a/src/app/modules/account/pages/home/home.component.html
+++ b/src/app/modules/account/pages/home/home.component.html
@@ -37,9 +37,7 @@
         </p>
       </div>
       <div class="col-sm-12 col-md-5 home__grandchild">
-        <div class="card mb-4" style="background-color : #f2f2f2;">
-          <br>
-          <aside class="home-alert__aside-wrapper">
+        <div class="card mb-4 home-alert__container">
             <div class="home-alert">
               <i class="fa fa-exclamation-triangle home-alert__icon" style="font-size: 35px;"></i>
               <p class="home-alert__text">
@@ -48,7 +46,6 @@
                 to request account changes.
               </p>
             </div>
-          </aside>
         </div>
       </div>
     </div> <br>

--- a/src/app/modules/account/pages/home/home.component.scss
+++ b/src/app/modules/account/pages/home/home.component.scss
@@ -105,10 +105,12 @@
   }
 
   // Wrapper around the alert container
-  &__aside-wrapper {
+  &__container{
       align-self: center;
       justify-self: center;
       width: 100%;
+      background-color : #f2f2f2;
+      padding: 20px 0px 0px 0px;
   }
 }
 


### PR DESCRIPTION
Hi,

I would like to ask for your quick code review. I've removed aside and changed it to div in order to the follow the header-main content-footer landmarks.

Here's the screenshot of the changes (Same style, just used div instead of aside):
![image](https://user-images.githubusercontent.com/47836606/95539702-edddfe00-09a3-11eb-9df6-56684f5d98bb.png)

Regards,
Cyril