### PR TITLE
DEA11Y-39: Add missing main tags

### DIFF
--- a/src/app/modules/account/pages/confirmation/confirmation.component.html
+++ b/src/app/modules/account/pages/confirmation/confirmation.component.html
@@ -1,100 +1,102 @@
-<common-page-framework layout="blank">
-  <div class="deam-container">
-    <common-confirm-template [displayIcon]="status">
-      <div confirmationTitle *ngIf="isSuccess; else ErrorTitle">
-        <a onclick="window.print();return false;">
-          <strong class="float-right">Print
-            <i class="fa fa-print fa-lg pointer" aria-hidden="true"></i>
-          </strong>
-        </a>
-        <h1><strong>Confirmation Message</strong></h1>
-        <p class="horizontal-line">
-          It is important to keep your reference number - write it down, or print this page for your records.
-        </p>
-      </div>
-      <div message *ngIf="isSuccess; else ErrorMsg">
-        <div class="icon--message">
-          Your update request has been submitted
+<main class="container-fluid" id="content">
+  <common-page-framework layout="blank">
+    <div class="deam-container">
+      <common-confirm-template [displayIcon]="status">
+        <div confirmationTitle *ngIf="isSuccess; else ErrorTitle">
+          <a onclick="window.print();return false;">
+            <strong class="float-right">Print
+              <i class="fa fa-print fa-lg pointer" aria-hidden="true"></i>
+            </strong>
+          </a>
+          <h1><strong>Confirmation Message</strong></h1>
+          <p class="horizontal-line">
+            It is important to keep your reference number - write it down, or print this page for your records.
+          </p>
         </div>
-
-        <div>
-          {{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}
+        <div message *ngIf="isSuccess; else ErrorMsg">
+          <div class="icon--message">
+            Your update request has been submitted
+          </div>
+  
+          <div>
+            {{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}
+          </div>
         </div>
-      </div>
-
-      <!-- If the user added a spouse or child with NO PREVIOUS MSP, means he/she is a completely new resident
-      to BC and needs to go to ICBC to get their picture taken, in this only case is when the 3rd blue box needs to be displayed.-->
-      <div *ngIf="isSuccess && hasAddedSpouseOrChildWithNoPrevMSP" AdditionalInfo>
-        <br>
-        <h2 class="horizontal-line"><strong>Next Steps</strong></h2>
-        <common-page-section layout='noTips'>
-          <div class="next-step--container">
-            <p>
-              <i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
-            </p>
-            <div>
-              To complete MSP enrolment, adult Canadian Citizens and Permanent Residents must obtain a Photo BC
-              Services Card by visiting an Insurance Corporation of BC (ICBC) driver licensing office. To find
-              an ICBC driver licensing office near you, please visit <a href="https://www.icbc.com" target="_blank">
-              icbc.com</a>.<br> <br>
-              If you have already been to an ICBC driver licensing office and requested a Photo BC Services Card,
-              no further action is required.
+  
+        <!-- If the user added a spouse or child with NO PREVIOUS MSP, means he/she is a completely new resident
+        to BC and needs to go to ICBC to get their picture taken, in this only case is when the 3rd blue box needs to be displayed.-->
+        <div *ngIf="isSuccess && hasAddedSpouseOrChildWithNoPrevMSP" AdditionalInfo>
+          <br>
+          <h2 class="horizontal-line"><strong>Next Steps</strong></h2>
+          <common-page-section layout='noTips'>
+            <div class="next-step--container">
+              <p>
+                <i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
+              </p>
+              <div>
+                To complete MSP enrolment, adult Canadian Citizens and Permanent Residents must obtain a Photo BC
+                Services Card by visiting an Insurance Corporation of BC (ICBC) driver licensing office. To find
+                an ICBC driver licensing office near you, please visit <a href="https://www.icbc.com" target="_blank">
+                icbc.com</a>.<br> <br>
+                If you have already been to an ICBC driver licensing office and requested a Photo BC Services Card,
+                no further action is required.
+              </div>
             </div>
-          </div>
-        </common-page-section>
-      </div>
-
-      <!-- If the user tried to remove a spouse or a child, the first blue box needs to be displayed just below the green box-->
-      <div *ngIf="hasRemovedSpouseOrChild" AdditionalInfo>
-        <br>
-        <common-page-section layout='noTips'>
-          <div class="next-step--container">
-            <p>
-              <i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
-            </p>
-            <div>
-              To remove a spouse or child from your MSP account due to a move outside B.C.
-              use the <a href="https://www.health.gov.bc.ca/exforms/msp/7063.html" target="_blank">
-              Permanent Move Outside British Columbia</a> form.
+          </common-page-section>
+        </div>
+  
+        <!-- If the user tried to remove a spouse or a child, the first blue box needs to be displayed just below the green box-->
+        <div *ngIf="hasRemovedSpouseOrChild" AdditionalInfo>
+          <br>
+          <common-page-section layout='noTips'>
+            <div class="next-step--container">
+              <p>
+                <i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
+              </p>
+              <div>
+                To remove a spouse or child from your MSP account due to a move outside B.C.
+                use the <a href="https://www.health.gov.bc.ca/exforms/msp/7063.html" target="_blank">
+                Permanent Move Outside British Columbia</a> form.
+              </div>
             </div>
-          </div>
-        </common-page-section>
-      </div>
-
-      <div *ngIf="isSuccess" AdditionalInfo>
-        <h2 class="horizontal-line"><strong>Important</strong></h2>
-        <common-page-section layout='noTips'>
-          <ul class="info--container">
-            <li>
-              Allow 21 business days for your application to be processed.
-            </li>
-            <li>
-              Living outside the province for more than six months could cause your Medical Services Plan enrolment to be cancelled. Learn more about the
-              <a href="{{links.MSP_ELIGIBILITY}}" target="_blank">eligibility for Medical Services Plan</a>.
-            </li>
-            <li>
-              Review <a href="{{links.FAQ}}" target="_blank">Frequently Asked Questions</a>.
-            </li>
-            <li>
-              If you require additional assistance, contact <a href="{{links.HIBC}}" target="_blank">Health Insurance B.C.</a>
-            </li>
-          </ul>
-        </common-page-section>
-      </div>
-    </common-confirm-template>
-  </div>
-</common-page-framework>
-
-<ng-template #ErrorTitle>
-  <div confirmationTitle>
-    <h1 class="horizontal-line">There was a technical issue with your submission</h1>
-  </div>
-</ng-template>
-
-<ng-template #ErrorMsg>
-  <div message>
-    <div class="icon--message">
-      Your application was not submitted
+          </common-page-section>
+        </div>
+  
+        <div *ngIf="isSuccess" AdditionalInfo>
+          <h2 class="horizontal-line"><strong>Important</strong></h2>
+          <common-page-section layout='noTips'>
+            <ul class="info--container">
+              <li>
+                Allow 21 business days for your application to be processed.
+              </li>
+              <li>
+                Living outside the province for more than six months could cause your Medical Services Plan enrolment to be cancelled. Learn more about the
+                <a href="{{links.MSP_ELIGIBILITY}}" target="_blank">eligibility for Medical Services Plan</a>.
+              </li>
+              <li>
+                Review <a href="{{links.FAQ}}" target="_blank">Frequently Asked Questions</a>.
+              </li>
+              <li>
+                If you require additional assistance, contact <a href="{{links.HIBC}}" target="_blank">Health Insurance B.C.</a>
+              </li>
+            </ul>
+          </common-page-section>
+        </div>
+      </common-confirm-template>
     </div>
-  </div>
-</ng-template>
+  </common-page-framework>
+  
+  <ng-template #ErrorTitle>
+    <div confirmationTitle>
+      <h1 class="horizontal-line">There was a technical issue with your submission</h1>
+    </div>
+  </ng-template>
+  
+  <ng-template #ErrorMsg>
+    <div message>
+      <div class="icon--message">
+        Your application was not submitted
+      </div>
+    </div>
+  </ng-template>
+</main>

--- a/src/app/modules/account/pages/home/home.component.html
+++ b/src/app/modules/account/pages/home/home.component.html
@@ -1,145 +1,147 @@
-<common-consent-modal #mspConsentModal class="consentModal" [isUnderMaintenance]="true"
-  [title]="'Information collection notice'"  [processName]="'ACL'"
-  [agreeLabel]="'I have read and understand this information'" (accept)="onAccept($event)"
-  (onClose)="manageAccount.focus()">
-  <p>
-    <strong>Keep your personal information secure – especially when using a shared device like a computer at a library,
-    school or café.</strong> To delete any information that was entered, either complete the request and submit it or,
-    if you don't finish, close the web browser.
-  </p>
-  <p>
-    <strong>Need to take a break and come back later?</strong> The data
-    you enter on this form is saved locally to the computer or device you are using until you close the web browser or
-    submit your request.
-  </p>
-  <p>
-    Personal information is collected under the authority of the <i>Medicare Protection Act</i> and section 26 (a), (c) and (e)
-    of the <i>Freedom of Information and Protection of Privacy Act</i> for the purposes of administration of the Medical
-    Services Plan. If you have any questions about the collection and use of your personal information, please contact
-    <a href="http://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">
-    Health Insurance BC <i class="fa fa-external-link" aria-hidden="true"></i></a>.
-  </p>
-</common-consent-modal>
-
-<common-page-framework layout="blank">
-  <div class="home">
-    <div class="row horizontal-line home__intro">
-      <h1><strong>Manage your Medical Services Plan Account</strong></h1>
-      <div class="col-sm-12 col-md-7 home__grandchild">
-        <p>
-          If you are an Account Holder with an active Medical Services Plan account, use this service to update or correct your
-          account information.
-        </p>
-        <p>
-          If you (and your spouse, if applicable) do not have an active Medical Services Plan account, 
-          <a href="https://www2.gov.bc.ca/MSP/applyforhealthcare" target="_blank">
-          Apply for Health Care <i class="fa fa-external-link" aria-hidden="true"></i></a>.
-        </p>
-      </div>
-      <div class="col-sm-12 col-md-5 home__grandchild">
-        <div class="card mb-4 home-alert__container">
-            <div class="home-alert">
-              <i class="fa fa-exclamation-triangle home-alert__icon" style="font-size: 35px;"></i>
-              <p class="home-alert__text">
-                If you are covered on an MSP Group Plan, in which your MSP coverage
-                is managed by your employer, union, or pension plan, please contact your MSP Group Plan Administrator
-                to request account changes.
-              </p>
-            </div>
+<main class="container-fluid" id="content">
+  <common-consent-modal #mspConsentModal class="consentModal" [isUnderMaintenance]="true"
+    [title]="'Information collection notice'"  [processName]="'ACL'"
+    [agreeLabel]="'I have read and understand this information'" (accept)="onAccept($event)"
+    (onClose)="manageAccount.focus()">
+    <p>
+      <strong>Keep your personal information secure – especially when using a shared device like a computer at a library,
+      school or café.</strong> To delete any information that was entered, either complete the request and submit it or,
+      if you don't finish, close the web browser.
+    </p>
+    <p>
+      <strong>Need to take a break and come back later?</strong> The data
+      you enter on this form is saved locally to the computer or device you are using until you close the web browser or
+      submit your request.
+    </p>
+    <p>
+      Personal information is collected under the authority of the <i>Medicare Protection Act</i> and section 26 (a), (c) and (e)
+      of the <i>Freedom of Information and Protection of Privacy Act</i> for the purposes of administration of the Medical
+      Services Plan. If you have any questions about the collection and use of your personal information, please contact
+      <a href="http://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">
+      Health Insurance BC <i class="fa fa-external-link" aria-hidden="true"></i></a>.
+    </p>
+  </common-consent-modal>
+  
+  <common-page-framework layout="blank">
+    <div class="home">
+      <div class="row horizontal-line home__intro">
+        <h1><strong>Manage your Medical Services Plan Account</strong></h1>
+        <div class="col-sm-12 col-md-7 home__grandchild">
+          <p>
+            If you are an Account Holder with an active Medical Services Plan account, use this service to update or correct your
+            account information.
+          </p>
+          <p>
+            If you (and your spouse, if applicable) do not have an active Medical Services Plan account, 
+            <a href="https://www2.gov.bc.ca/MSP/applyforhealthcare" target="_blank">
+            Apply for Health Care <i class="fa fa-external-link" aria-hidden="true"></i></a>.
+          </p>
         </div>
-      </div>
-    </div> <br>
-    <div class="row home__options">
-      <div class="col-sm-12 col-md-6 home__grandchild">
-        <div class="card mb-4 h-100">
-          <div class="card-header cardHeader" >
-            <h2 class="cardHeaderText">Manage Your Account</h2>
-          </div>
-          <div class="card-body d-flex flex-column">
-            <!-- <p class="card-text"> -->
-            Update personal information for yourself, your spouse, or children, including:
-            <ul>
-              <li>
-                Legal name
-              </li>
-              <li>
-                Birthdate
-              </li>
-              <li>
-                Gender designation
-              </li>
-            </ul>
-            Update or renew immigration status in Canada for yourself, your spouse, or children, including:
-            <ul>
-              <li>
-                Canadian citizenship
-              </li>
-              <li>
-                Permanent Resident status
-              </li>
-              <li>
-                New or updated temporary immigration permits
-              </li>
-            </ul>
-            <p>
-              Add a new spouse or remove a spouse on your account
-            </p>
-            <p>
-              Add children or remove children on your account
-            </p>
-            <button #manageAccount type="button" class="mt-auto btn btn-primary btn-md" routerLink="/deam/personal-info">
-              <span>Manage Account</span>
-            </button>
+        <div class="col-sm-12 col-md-5 home__grandchild">
+          <div class="card mb-4 home-alert__container">
+              <div class="home-alert">
+                <i class="fa fa-exclamation-triangle home-alert__icon" style="font-size: 35px;"></i>
+                <p class="home-alert__text">
+                  If you are covered on an MSP Group Plan, in which your MSP coverage
+                  is managed by your employer, union, or pension plan, please contact your MSP Group Plan Administrator
+                  to request account changes.
+                </p>
+              </div>
           </div>
         </div>
       </div> <br>
-
-      <div class="col-sm-12 col-md-6 home__grandchild">
-        <div class="card h-100" >
-          <div class="card-header cardHeader">
-            <h2 class="cardHeaderText">Address Change Only</h2>
-          </div>
-          <div class="card-body d-flex flex-column">
-            <p>
-              To report a move within B.C. click "Report an address change in B.C.” You will be redirected to Address Change B.C.
-            </p>
-            <p>
-              If you (or a spouse/child on your account) are leaving B.C. permanently, click “Report a move outside B.C.”
-              You will be redirected to the "Permanent Move Outside British Columbia" form to cancel MSP coverage for the
-              individuals who have moved out of province.
-            </p>
-            <div class="btn-group-vertical mt-auto" role="group">
-              <button type="button" class="btn btn-primary btn-md btn-block" (click)="onClickAddressChange()">
-                Report an address change in B.C. <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
-              </button> <br>
-              <button type="button" class="btn btn-primary btn-md btn-block" (click)="onClickMove()" class="mt-auto btn btn-primary">
-                Report a move outside B.C. <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
+      <div class="row home__options">
+        <div class="col-sm-12 col-md-6 home__grandchild">
+          <div class="card mb-4 h-100">
+            <div class="card-header cardHeader" >
+              <h2 class="cardHeaderText">Manage Your Account</h2>
+            </div>
+            <div class="card-body d-flex flex-column">
+              <!-- <p class="card-text"> -->
+              Update personal information for yourself, your spouse, or children, including:
+              <ul>
+                <li>
+                  Legal name
+                </li>
+                <li>
+                  Birthdate
+                </li>
+                <li>
+                  Gender designation
+                </li>
+              </ul>
+              Update or renew immigration status in Canada for yourself, your spouse, or children, including:
+              <ul>
+                <li>
+                  Canadian citizenship
+                </li>
+                <li>
+                  Permanent Resident status
+                </li>
+                <li>
+                  New or updated temporary immigration permits
+                </li>
+              </ul>
+              <p>
+                Add a new spouse or remove a spouse on your account
+              </p>
+              <p>
+                Add children or remove children on your account
+              </p>
+              <button #manageAccount type="button" class="mt-auto btn btn-primary btn-md" routerLink="/deam/personal-info">
+                <span>Manage Account</span>
               </button>
+            </div>
+          </div>
+        </div> <br>
+  
+        <div class="col-sm-12 col-md-6 home__grandchild">
+          <div class="card h-100" >
+            <div class="card-header cardHeader">
+              <h2 class="cardHeaderText">Address Change Only</h2>
+            </div>
+            <div class="card-body d-flex flex-column">
+              <p>
+                To report a move within B.C. click "Report an address change in B.C.” You will be redirected to Address Change B.C.
+              </p>
+              <p>
+                If you (or a spouse/child on your account) are leaving B.C. permanently, click “Report a move outside B.C.”
+                You will be redirected to the "Permanent Move Outside British Columbia" form to cancel MSP coverage for the
+                individuals who have moved out of province.
+              </p>
+              <div class="btn-group-vertical mt-auto" role="group">
+                <button type="button" class="btn btn-primary btn-md btn-block" (click)="onClickAddressChange()">
+                  Report an address change in B.C. <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
+                </button> <br>
+                <button type="button" class="btn btn-primary btn-md btn-block" (click)="onClickMove()" class="mt-auto btn btn-primary">
+                  Report a move outside B.C. <i class="fa fa-external-link fa-fw" aria-hidden="true"></i>
+                </button>
+              </div>
             </div>
           </div>
         </div>
       </div>
-    </div>
-    <div class="row mt-3" *ngIf="showAddressChangeCaptcha || showMoveCaptcha">
-      <div class="col-12">
-        <div class="text-danger mb-3">You will be redirected to {{outLinkTitle}} to complete you request. Please complete the field below and click Continue.</div>
-        <common-captcha
-          name="captcha"
-          [apiBaseUrl]="captchaApiBaseUrl" [nonce]="mspAccountApp.uuid"
-          (onValidToken)="mspAccountApp.authorizationToken = $event"
-          ngModel
-          required>
-        </common-captcha>
+      <div class="row mt-3" *ngIf="showAddressChangeCaptcha || showMoveCaptcha">
+        <div class="col-12">
+          <div class="text-danger mb-3">You will be redirected to {{outLinkTitle}} to complete you request. Please complete the field below and click Continue.</div>
+          <common-captcha
+            name="captcha"
+            [apiBaseUrl]="captchaApiBaseUrl" [nonce]="mspAccountApp.uuid"
+            (onValidToken)="mspAccountApp.authorizationToken = $event"
+            ngModel
+            required>
+          </common-captcha>
+        </div>
       </div>
     </div>
-  </div>
-</common-page-framework>
-
-<common-form-action-bar
-  *ngIf="mspAccountApp.authorizationToken"
-  [defaultColor]="false"
-  [submitLabel]="'Continue'"
-  [canContinue]="true"
-  [isLoading]="continueButtonLoading"
-  (btnClick)="continue($event)">
-</common-form-action-bar>
+  </common-page-framework>
+  
+  <common-form-action-bar
+    *ngIf="mspAccountApp.authorizationToken"
+    [defaultColor]="false"
+    [submitLabel]="'Continue'"
+    [canContinue]="true"
+    [isLoading]="continueButtonLoading"
+    (btnClick)="continue($event)">
+  </common-form-action-bar>
+</main>

--- a/src/app/modules/assistance/pages/confirmation/confirmation.component.ts
+++ b/src/app/modules/assistance/pages/confirmation/confirmation.component.ts
@@ -6,7 +6,8 @@ import { tap, map } from 'rxjs/operators';
 
 @Component({
   template: `
-  <common-page-framework layout="blank">
+  <main class="container-fluid" id="content">
+    <common-page-framework layout="blank">
 
       <ng-container *ngIf="success">
         <!-- SUCCESS: {{ success$ | async | json }} -->
@@ -39,6 +40,7 @@ import { tap, map } from 'rxjs/operators';
           </msp-confirmation>
       </ng-container>
     </common-page-framework>
+  </main>
   `,
   styleUrls: ['./confirmation.component.scss']
 })

--- a/src/app/modules/benefit/pages/confirmation/confirmation.component.html
+++ b/src/app/modules/benefit/pages/confirmation/confirmation.component.html
@@ -1,78 +1,77 @@
-<common-page-framework layout="blank">
-  <div *ngIf="benefitApp.isEligible != false">  
-        
-    <a onclick="window.print();return false;" >   
-    <b class="float-right">Print <i class="fa fa-print fa-lg pointer" 
-        aria-hidden="true"></i>
-    </b>
-    </a>
-    <h1>Confirmation Message</h1>
-    <hr>
-
-      <div class="row" style="border-style: solid; color:#83D31D" >
-          <div class="col-sm-.5" style="font-size: 50px; margin-top: 10px;margin-left: 15px" ><i class="fa fa-check-circle" aria-hidden="true"></i></div>
-          <div class="col-10">
-              <h2>
-                  Your application has been submitted
-              </h2>
-              <p class="font-weight-normal h4">{{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}</p>
-              <div class="row font-weight-normal h3" style="margin-left: 0px;">
-                <div style="font-size: 30px; margin-top: -8px;">
-                    &middot;
-                </div>
-                <div class="col-11">
-                    {{noticeOfAssessment}} 
-                </div>
-
-              </div>
-              
-          </div>
-      </div>
-    
-    <h2>Next Steps</h2>
-    <hr>
-    
-        <ul>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').printEmailInstructions" onclick="window.print();" class="pointer"></h3>
-            </li>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').generalInstructions1"></h3>
-            </li>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').generalInstructions2"></h3>
-            </li>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').generalInstructions3"></h3>
-            </li>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').generalInstructions4"></h3>
-            </li>
-            <li>
-              <h3 [innerHTML]="lang('./en/index.js').generalInstructions5"></h3>
-            </li>
-          </ul>
-      </div>
-      
-      <!-- Not Eligible Section -->
-      <div *ngIf="benefitApp.isEligible == false"> 
-          <h1>Eligibility Message</h1>
-          <hr>
-          <div style="border-style: solid; color:rgba(0, 0, 191, 1);" >
-            <div class="container">
-                <h2> <i class="fa fa-exclamation-circle" aria-hidden="true"></i> You are not eligible to apply at this time 
+<main class="container-fluid" id="content">
+  <common-page-framework layout="blank">
+    <div *ngIf="benefitApp.isEligible != false">  
+          
+      <a onclick="window.print();return false;" >   
+      <b class="float-right">Print <i class="fa fa-print fa-lg pointer" 
+          aria-hidden="true"></i>
+      </b>
+      </a>
+      <h1>Confirmation Message</h1>
+      <hr>
+  
+        <div class="row" style="border-style: solid; color:#83D31D" >
+            <div class="col-sm-.5" style="font-size: 50px; margin-top: 10px;margin-left: 15px" ><i class="fa fa-check-circle" aria-hidden="true"></i></div>
+            <div class="col-10">
+                <h2>
+                    Your application has been submitted
                 </h2>
-                <h3>
-                  Please make a new application when you meet the residency requirements. For assistance please contact <a href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">Health Insurance BC.</a> 
-                </h3>
-                <h3>
-                  For more information on eligibility requirements visit <a href="https://gov.bc.ca/MSP/supplementarybenefits" target="_blank">Applying for Supplementary Benefit.</a>
-                </h3>
+                <p class="font-weight-normal h4">{{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}</p>
+                <div class="row font-weight-normal h3" style="margin-left: 0px;">
+                  <div style="font-size: 30px; margin-top: -8px;">
+                      &middot;
+                  </div>
+                  <div class="col-11">
+                      {{noticeOfAssessment}} 
+                  </div>
+  
+                </div>
+                
             </div>
-          </div>
-      </div>
-    
-</common-page-framework>
-
-
-
+        </div>
+      
+      <h2>Next Steps</h2>
+      <hr>
+      
+          <ul>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').printEmailInstructions" onclick="window.print();" class="pointer"></h3>
+              </li>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').generalInstructions1"></h3>
+              </li>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').generalInstructions2"></h3>
+              </li>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').generalInstructions3"></h3>
+              </li>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').generalInstructions4"></h3>
+              </li>
+              <li>
+                <h3 [innerHTML]="lang('./en/index.js').generalInstructions5"></h3>
+              </li>
+            </ul>
+        </div>
+        
+        <!-- Not Eligible Section -->
+        <div *ngIf="benefitApp.isEligible == false"> 
+            <h1>Eligibility Message</h1>
+            <hr>
+            <div style="border-style: solid; color:rgba(0, 0, 191, 1);" >
+              <div class="container">
+                  <h2> <i class="fa fa-exclamation-circle" aria-hidden="true"></i> You are not eligible to apply at this time 
+                  </h2>
+                  <h3>
+                    Please make a new application when you meet the residency requirements. For assistance please contact <a href="https://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">Health Insurance BC.</a> 
+                  </h3>
+                  <h3>
+                    For more information on eligibility requirements visit <a href="https://gov.bc.ca/MSP/supplementarybenefits" target="_blank">Applying for Supplementary Benefit.</a>
+                  </h3>
+              </div>
+            </div>
+        </div>
+      
+  </common-page-framework>
+</main>  

--- a/src/app/modules/benefit/pages/eligibility/eligibility.component.html
+++ b/src/app/modules/benefit/pages/eligibility/eligibility.component.html
@@ -1,51 +1,53 @@
 
-<common-consent-modal #mspConsentModal [isUnderMaintenance]="true" (cutOffDate)= "spaEnvCutOffDate($event)"
-  title="Information collection notice" agreeLabel="I have read and understand this information"
-  [processName]="'SUPPBEN'" (accept)="benefitApp.infoCollectionAgreement = $event; this.dataService.saveBenefitApplication();">
-  <p><strong>Keep your personal information secure – especially when using a shared device like a computer at a library, school or café.</strong> To delete any information that was entered, either complete the application and submit it or, if you don’t finish, close the web browser.</p><p><strong>Need to take a break and come back later?</strong> The data you enter on this form is saved locally to the computer or device you are using until you close the web browser or submit your application.</p><p>
-        Personal information is collected under the authority of the <i>Medicare Protection Act</i> and section 26 (a), (c) and (e) of the <i>Freedom of Information and Protection of Privacy Act</i> for the purposes of administration of the Medical Services Plan. If you have any questions about the collection and use of your personal information, please <a href="http://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">contact Health Insurance BC <i class="fa fa-external-link" aria-hidden="true"></i></a>.</p>
-</common-consent-modal>
-<common-page-framework layout="blank">
-  <div class="row">
-    <h1>
-      Supplementary Benefits
-    </h1>
+<main class="container-fluid" id="content">
+  <common-consent-modal #mspConsentModal [isUnderMaintenance]="true" (cutOffDate)= "spaEnvCutOffDate($event)"
+    title="Information collection notice" agreeLabel="I have read and understand this information"
+    [processName]="'SUPPBEN'" (accept)="benefitApp.infoCollectionAgreement = $event; this.dataService.saveBenefitApplication();">
+    <p><strong>Keep your personal information secure – especially when using a shared device like a computer at a library, school or café.</strong> To delete any information that was entered, either complete the application and submit it or, if you don’t finish, close the web browser.</p><p><strong>Need to take a break and come back later?</strong> The data you enter on this form is saved locally to the computer or device you are using until you close the web browser or submit your application.</p><p>
+          Personal information is collected under the authority of the <i>Medicare Protection Act</i> and section 26 (a), (c) and (e) of the <i>Freedom of Information and Protection of Privacy Act</i> for the purposes of administration of the Medical Services Plan. If you have any questions about the collection and use of your personal information, please <a href="http://www2.gov.bc.ca/gov/content/health/health-drug-coverage/msp/bc-residents-contact-us" target="_blank">contact Health Insurance BC <i class="fa fa-external-link" aria-hidden="true"></i></a>.</p>
+  </common-consent-modal>
+  <common-page-framework layout="blank">
+    <div class="row">
+      <h1>
+        Supplementary Benefits
+      </h1>
+    </div>
+    <div class="row">
+  
+        To be eligible for Supplementary Benefits you must meet the residency requirement.
+  
+    </div>
+  
+    <div class="row">
+        <h2>
+          <strong>
+            Residency Requirement
+          </strong>
+        </h2>
+    </div>
+    <div class="row">
+        Please read and confirm:
+    </div>
+    <div class="row">
+        <ul>
+            <li>I am a resident of British Columbia as defined by the <i>Medicare Protection Act</i>.</li>
+            <li>I have resided in Canada as a Canadian citizen or holder of permanent resident status (landed immigrant) for at least the last 12 months immediately preceding this application. I am not exempt from liability to pay income tax by reason of any other Act.</li>
+        </ul>
+    </div>
+    <hr>
+   <div class="row">
+    <div class="form-group">
+        <common-radio [value]="dataService.benefitApp.isEligible"  [label]="'Do you meet the residency requirement?'"
+            [radioLabels]='[{"label": "No", "value": false}, {"label": "Yes", "value": true}]'
+            (valueChange)="dataService.benefitApp.isEligible = $event; this.continue=true; this.dataService.saveBenefitApplication(); ">
+        </common-radio>
+    </div>
   </div>
-  <div class="row">
-
-      To be eligible for Supplementary Benefits you must meet the residency requirement.
-
-  </div>
-
-  <div class="row">
-      <h2>
-        <strong>
-          Residency Requirement
-        </strong>
-      </h2>
-  </div>
-  <div class="row">
-      Please read and confirm:
-  </div>
-  <div class="row">
-      <ul>
-          <li>I am a resident of British Columbia as defined by the <i>Medicare Protection Act</i>.</li>
-          <li>I have resided in Canada as a Canadian citizen or holder of permanent resident status (landed immigrant) for at least the last 12 months immediately preceding this application. I am not exempt from liability to pay income tax by reason of any other Act.</li>
-      </ul>
-  </div>
-  <hr>
- <div class="row">
-  <div class="form-group">
-      <common-radio [value]="dataService.benefitApp.isEligible"  [label]="'Do you meet the residency requirement?'"
-          [radioLabels]='[{"label": "No", "value": false}, {"label": "Yes", "value": true}]'
-          (valueChange)="dataService.benefitApp.isEligible = $event; this.continue=true; this.dataService.saveBenefitApplication(); ">
-      </common-radio>
-  </div>
-</div>
-
-</common-page-framework>
-<common-form-action-bar [submitLabel]="'Apply for Supplementary Benefits'"
-        [canContinue]="dataService.benefitApp.isEligible != undefined "
-        (btnClick)="navigate()"
-        widthOption='extra-width-mobile-only'>
-</common-form-action-bar>
+  
+  </common-page-framework>
+  <common-form-action-bar [submitLabel]="'Apply for Supplementary Benefits'"
+          [canContinue]="dataService.benefitApp.isEligible != undefined "
+          (btnClick)="navigate()"
+          widthOption='extra-width-mobile-only'>
+  </common-form-action-bar>
+</main>

--- a/src/app/modules/enrolment/pages/confirmation/confirmation.component.html
+++ b/src/app/modules/enrolment/pages/confirmation/confirmation.component.html
@@ -1,94 +1,96 @@
-<common-page-framework layout="blank">
-	<common-confirm-template [displayIcon]="status">
-		<div confirmationTitle *ngIf="isSucess; else ErrorTitle;">
-			<a onclick="window.print();return false;">
-				<strong class="float-right">Print
-					<i class="fa fa-print fa-lg pointer" aria-hidden="true"></i>
-				</strong>
-			</a>
-			<h1 class="border-bottom">Confirmation Message</h1>
-		</div>
-		<div message *ngIf="isSucess; else IconErrMsg">
-			<p class="icon--message">
-				Your application has been submitted
-			</p>
-			<p>
-				{{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}
-			</p>
-		</div>
-
-		<div *ngIf="isSucess" AdditionalInfo>
-			<div *ngIf="nextSteps">
-				<h2 class="border-bottom">Next Steps</h2>
-				<common-page-section layout='noTips'>
-					<div class="next-step--container">
-						<p>
-							<i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
-						</p>
-						<div>
+<main class="container-fluid" id="content">
+	<common-page-framework layout="blank">
+		<common-confirm-template [displayIcon]="status">
+			<div confirmationTitle *ngIf="isSucess; else ErrorTitle;">
+				<a onclick="window.print();return false;">
+					<strong class="float-right">Print
+						<i class="fa fa-print fa-lg pointer" aria-hidden="true"></i>
+					</strong>
+				</a>
+				<h1 class="border-bottom">Confirmation Message</h1>
+			</div>
+			<div message *ngIf="isSucess; else IconErrMsg">
+				<p class="icon--message">
+					Your application has been submitted
+				</p>
+				<p>
+					{{dateStamp}} - Reference # {{confirmationNum? confirmationNum : 'N/A'}}
+				</p>
+			</div>
+	
+			<div *ngIf="isSucess" AdditionalInfo>
+				<div *ngIf="nextSteps">
+					<h2 class="border-bottom">Next Steps</h2>
+					<common-page-section layout='noTips'>
+						<div class="next-step--container">
 							<p>
-								To complete Medical Services Plan enrolment, adult Canadian Citizens and Permanent Residents must 
-								obtain a Photo BC Services Card by visiting an Insurance Corporation of BC (ICBC) 
-								driver licensing office. To find an ICBC driver licensing office near you, please 
-								visit <a href="{{links.ICBC}}" target="_blank">icbc.com</a>.
+								<i class="fa fa-2x fa-exclamation-circle next-step--color pr-2" aria-label="next steps"></i>
 							</p>
-							<p>
-								If you have already been to an ICBC driver licensing office and requested a Photo 
-								BC Services Card, no further action is required.
-							</p>
+							<div>
+								<p>
+									To complete Medical Services Plan enrolment, adult Canadian Citizens and Permanent Residents must 
+									obtain a Photo BC Services Card by visiting an Insurance Corporation of BC (ICBC) 
+									driver licensing office. To find an ICBC driver licensing office near you, please 
+									visit <a href="{{links.ICBC}}" target="_blank">icbc.com</a>.
+								</p>
+								<p>
+									If you have already been to an ICBC driver licensing office and requested a Photo 
+									BC Services Card, no further action is required.
+								</p>
+							</div>
 						</div>
-					</div>
+					</common-page-section>
+				</div>
+	
+				<h2 class="border-bottom">Information</h2>
+				<common-page-section layout='noTips'>
+					<ul class="info--container">
+						<li>
+							<strong>Important:</strong> Keep your reference number - write it down, or print this page for your records
+						</li>
+						<li>
+							Allow 21 business days for your application to be processed.
+						</li>
+						<li>
+							<strong>After your application is processed,</strong> Health Insurance BC will mail a letter to confirm your Medical Services Plan 
+							enrolment status. You may have a <a href="{{links.MSP_WAIT_PERIOD}}" target="_blank">wait period</a>.
+						</li>
+						<li>
+							When you get your BC Services Card, register for the <a href="{{links.FPCARE}}" target="_blank">Fair Pharmacare plan</a>. It can help 
+							with the cost of prescription drugs and some medical supplies. Registration is free.
+						</li>
+						<li>
+							Keep your personal information up to date. <a href="{{links.BCSC_UPDATE}}" target="_blank">Change your name, address or gender</a>.
+						</li>	
+						<li>
+							Living outside the province for more than six months could cause your Medical Services Plan enrolment to be cancelled. 
+							<a href="{{links.MSP_ELIGIBILITY}}" target="_blank">Learn more about eligibility for Medical Services Plan</a>.
+						</li>
+						<li>
+							If you have questions, contact <a href="{{links.HIBC}}" target="_blank">Health Insurance BC</a>.
+						</li>
+					</ul>
 				</common-page-section>
 			</div>
-
-			<h2 class="border-bottom">Information</h2>
-			<common-page-section layout='noTips'>
-				<ul class="info--container">
-          <li>
-            <strong>Important:</strong> Keep your reference number - write it down, or print this page for your records
-          </li>
-					<li>
-						Allow 21 business days for your application to be processed.
-					</li>
-				  <li>
-						<strong>After your application is processed,</strong> Health Insurance BC will mail a letter to confirm your Medical Services Plan 
-						enrolment status. You may have a <a href="{{links.MSP_WAIT_PERIOD}}" target="_blank">wait period</a>.
-					</li>
-					<li>
-						When you get your BC Services Card, register for the <a href="{{links.FPCARE}}" target="_blank">Fair Pharmacare plan</a>. It can help 
-						with the cost of prescription drugs and some medical supplies. Registration is free.
-					</li>
-					<li>
-						Keep your personal information up to date. <a href="{{links.BCSC_UPDATE}}" target="_blank">Change your name, address or gender</a>.
-					</li>	
-					<li>
-						Living outside the province for more than six months could cause your Medical Services Plan enrolment to be cancelled. 
-						<a href="{{links.MSP_ELIGIBILITY}}" target="_blank">Learn more about eligibility for Medical Services Plan</a>.
-					</li>
-					<li>
-						If you have questions, contact <a href="{{links.HIBC}}" target="_blank">Health Insurance BC</a>.
-					</li>
-				</ul>
-			</common-page-section>
+		</common-confirm-template>
+	</common-page-framework>
+	
+	
+	<ng-template #ErrorTitle>
+		<div confirmationTitle>
+				<h1 class="border-bottom">There was a technical issue with your submission</h1>
 		</div>
-	</common-confirm-template>
-</common-page-framework>
-
-
-<ng-template #ErrorTitle>
-	<div confirmationTitle>
-			<h1 class="border-bottom">There was a technical issue with your submission</h1>
-	</div>
-</ng-template>
-
-
-<ng-template #IconErrMsg>
-	<div message>
-		<p class="icon--message">
-				Your application was not submitted
-		</p>
-		<p>
-			{{message}}
-		</p>
-	</div>
-</ng-template>
+	</ng-template>
+	
+	
+	<ng-template #IconErrMsg>
+		<div message>
+			<p class="icon--message">
+					Your application was not submitted
+			</p>
+			<p>
+				{{message}}
+			</p>
+		</div>
+	</ng-template>
+</main>

--- a/src/app/pages/landing/landing.component.html
+++ b/src/app/pages/landing/landing.component.html
@@ -1,47 +1,49 @@
-<div class="container" style="margin-top: 30px; margin-bottom: 30px;">
-
-  <div class="row">
-    <div class="col-sm-12 col-md-6">
-      <br>
-      <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedMspApp()">
-        {{newEnrollApp}}
-      </button>
+<main class="container-fluid" id="content">
+  <div class="container" style="margin-top: 30px; margin-bottom: 30px;">
+  
+    <div class="row">
+      <div class="col-sm-12 col-md-6">
+        <br>
+        <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedMspApp()">
+          {{newEnrollApp}}
+        </button>
+      </div>
+  
+      <div class="col-sm-12 col-md-6">
+        <br>
+        <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedFinAssisApp()">
+          {{newPaApp}}
+        </button>
+      </div>
     </div>
-
-    <div class="col-sm-12 col-md-6">
-      <br>
-      <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedFinAssisApp()">
-        {{newPaApp}}
-      </button>
+  
+    <div class="row">
+      <div class="col-sm-12 col-md-6">
+        <hr>
+        <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedAccountApp()">
+          {{newAccountApp}}
+        </button>
+      </div>
+  
+  
+  
+      <div class="col-sm-12 col-md-6">
+        <hr>
+        <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedAclApplication()">
+          {{newAccountLetter}}
+        </button>
+      </div>
+  
     </div>
+  
+    <div class="row">
+      <div class="col-sm-12 col-md-6">
+        <hr>
+        <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedBenefitAssisApp()">
+          {{newBenefitApp}}
+        </button>
+      </div>
+    </div>
+  
   </div>
-
-  <div class="row">
-    <div class="col-sm-12 col-md-6">
-      <hr>
-      <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedAccountApp()">
-        {{newAccountApp}}
-      </button>
-    </div>
-
-
-
-    <div class="col-sm-12 col-md-6">
-      <hr>
-      <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedAclApplication()">
-        {{newAccountLetter}}
-      </button>
-    </div>
-
-  </div>
-
-  <div class="row">
-    <div class="col-sm-12 col-md-6">
-      <hr>
-      <button class="btn btn-primary btn-lg btn-block" (click)="clearSavedBenefitAssisApp()">
-        {{newBenefitApp}}
-      </button>
-    </div>
-  </div>
-
-</div>
+</main>


### PR DESCRIPTION
Has no visible effect but for accessibility a main tag must always be present. On pages like `confirmation` that don't use their respective container components the main tags needed to be added in. This is all so navigation can be outside of main but main can still skip users to the content