### PR TITLE
Add focusing to spouse and child button clicks

### DIFF
--- a/src/app/modules/account/pages/child-info/child-info.component.ts
+++ b/src/app/modules/account/pages/child-info/child-info.component.ts
@@ -172,11 +172,12 @@ export class ChildInfoComponent extends BaseForm implements OnInit, AfterViewIni
   }
 
   scrollToChild(section: string) {
-    const elements = document.querySelectorAll(section);
-    if (elements.length > 0) {
-      const el: Element = elements[0];
+    const el = <HTMLElement>document.querySelector(section);
+    if (el) {
       const top: number = el.getBoundingClientRect().top + window.pageYOffset - 75;
       scrollTo(top);
+      // Focus first input of section
+      el.querySelector('input').focus();
     }
   }
 

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.html
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.html
@@ -42,7 +42,7 @@
       <br>
 
       <!-- Add Spouse Section -->
-      <div *ngIf="showAddSpouse">
+      <div *ngIf="showAddSpouse" class="add-spouse">
         <h2><strong>Add Spouse</strong></h2>
         <common-xicon-button
           label='Remove'
@@ -60,7 +60,7 @@
       </div>
 
       <!-- Remove Spouse Section -->
-      <div *ngIf="showRemoveSpouse">
+      <div *ngIf="showRemoveSpouse" class="remove-spouse">
         <h2><strong>Remove Spouse</strong></h2>
         <common-xicon-button
           label='Remove'
@@ -77,7 +77,7 @@
       </div>
 
       <!-- Update Spouse Section -->
-      <div *ngIf="showUpdateSpouse">
+      <div *ngIf="showUpdateSpouse" class="update-spouse">
         <h2><strong>Update Spouse's Information</strong></h2>
         <common-xicon-button
           label='Remove'
@@ -96,7 +96,7 @@
         </msp-update-spouse>
       </div>
 
-      <!-- Add/Remove/Update Buttons-->
+      <!-- Add/Remove/Update Buttons -->
       <div *ngIf="((showAddSpouse && showAddedSpouseBottomButtons) || showUpdateSpouse || showRemoveSpouse)">
         <p class="horizontal-line"></p>
         <div class="row aru-buttons">

--- a/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
+++ b/src/app/modules/account/pages/spouse-info/spouse-info.component.ts
@@ -4,13 +4,15 @@ import { MspAccountMaintenanceDataService } from '../../services/msp-account-dat
 import { Subscription } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { NgForm } from '@angular/forms';
-import { ContainerService, PageStateService } from 'moh-common-lib';
+import { ContainerService, PageStateService, scrollTo } from 'moh-common-lib';
 import { Router } from '@angular/router';
 import { MspPerson } from '../../../../components/msp/model/msp-person.model';
 import { Relationship } from 'app/models/relationship.enum';
 import { BaseForm } from '../../models/base-form';
 import { CancellationReasons } from '../../../../models/status-activities-documents';
 import {ProcessService} from '../../../../services/process.service';
+
+const DOM_REFRESH_TIMEOUT = 50;
 
 @Component({
   selector: 'msp-spouse-info',
@@ -76,6 +78,11 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
     this.accountChangeOptions.dependentChange = true;
     this.showAddSpouse = true;
     this.showUpdateSpouse = false;
+        
+    setTimeout(() => {
+      this.scrollToSpouse('.add-spouse');
+    }, DOM_REFRESH_TIMEOUT);
+
     return this.showAddSpouse;
   }
 
@@ -85,6 +92,11 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
     this.accountChangeOptions.dependentChange = true;
     this.showRemoveSpouse = true;
     this.showUpdateSpouse = false;
+        
+    setTimeout(() => {
+      this.scrollToSpouse('.remove-spouse');
+    }, DOM_REFRESH_TIMEOUT);
+
     return this.showRemoveSpouse;
   }
 
@@ -95,7 +107,22 @@ export class SpouseInfoComponent extends BaseForm implements OnInit, AfterViewIn
     this.showRemoveSpouse = false;
     this.showAddSpouse = false;
     this.showUpdateSpouse = true;
+
+    setTimeout(() => {
+      this.scrollToSpouse('.update-spouse');
+    }, DOM_REFRESH_TIMEOUT);
+
     return this.showUpdateSpouse;
+  }
+
+  scrollToSpouse(section: string) {
+    const el = <HTMLElement>document.querySelector(section);
+    if (el) {
+      const top: number = el.getBoundingClientRect().top + window.pageYOffset - 75;
+      scrollTo(top);
+      // Focus first input of section
+      el.querySelector('input').focus();
+    }
   }
 
   removedAddedSpouse() {


### PR DESCRIPTION
Accessibility update, to adjust focus after button clicks. To test, click the add, update, and remove buttons for children and spouse, ensuring that the focus moves to the first input of each

